### PR TITLE
CleanSpeak integration (backend)

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -22,5 +22,7 @@ module.exports = {
 	//Twilio Credentials
 	accountSid: '',
 	authToken: '',
-	sendingNumber: ''
+	sendingNumber: '',
+
+	cleanSpeakApiKey: ''
 };

--- a/controllers/ModerationCtrl.js
+++ b/controllers/ModerationCtrl.js
@@ -1,0 +1,50 @@
+const https = require('https');
+const API_KEY = require('../config').cleanSpeakApiKey;
+
+module.exports = {
+  
+  moderateMessage: (data, callback) => {
+
+    const req = https.request({
+      hostname: 'upchieve-cleanspeak-api.inversoft.io',
+      path: '/content/item/filter',
+      method: 'POST',
+      headers: {
+        'Authorization': API_KEY,
+        'Content-Type': 'application/json'
+      }
+    },
+    (res) => {
+
+      let resBody = '';
+      res.on('data', (chunk) => {
+        resBody += chunk;
+      });
+
+      res.on('end', () => {
+        console.log('CleanSpeak response body:', resBody);
+
+        if (res.statusCode === 200) {
+          resBody = JSON.parse(resBody);
+
+          if (resBody.matches.length === 0) {
+            callback(null, true);
+          }
+          else {
+            callback(null, false);
+          }
+        }
+
+        else {
+          callback(`CleanSpeak API didn't send desired response: { statusCode: ${res.statusCode}, body: ${resBody} }`);
+        }  
+      });
+    });
+
+    req.on('error', (err) => { 
+      callback(err); 
+    });
+    req.write(JSON.stringify(data));
+    req.end();
+  }
+}

--- a/router/api/index.js
+++ b/router/api/index.js
@@ -12,6 +12,7 @@ module.exports = function(app){
 	require('./calendar')(router);
 	require('./training')(router);
 	require('./sockets')(app);
+  require('./moderate')(router);
 
 	app.use('/api', passport.isAuthenticated, router);
 };

--- a/router/api/moderate.js
+++ b/router/api/moderate.js
@@ -1,0 +1,16 @@
+const ModerationCtrl = require('../../controllers/ModerationCtrl');
+
+module.exports = (router) => {
+
+  router.route('/moderate/message').post((req, res) => {
+    ModerationCtrl.moderateMessage(req.body, (err, isClean) => {
+      if (err) {
+        console.log(err);
+        res.json({ 'err': err });
+      }
+      else {
+        res.json({ 'isClean': isClean });
+      }
+    });
+  });
+}


### PR DESCRIPTION
New end point:

### POST /moderate/message

Expects the following request body:
```json
{
  "content": "string with the content of a message"
}
```

Makes a call to [CleanSpeak's Filter Content API](https://www.inversoft.com/docs/cleanspeak/3.x/tech/tutorials/filtering-content#using-the-filter-content-api), analyzes the API's response, and returns a boolean indicating whether or not the message is clean.