### PR TITLE
Added guard to notifications

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -194,7 +194,10 @@ module.exports = {
       subTopic: subTopic
     });
 
-    twilioService.notify(type, subTopic);
+    if (!user.isTestUser) {
+      twilioService.notify(type, subTopic);
+    }
+
     session.save(cb);
   },
 

--- a/models/User.js
+++ b/models/User.js
@@ -223,6 +223,10 @@ planning: {
     type: Boolean,
     default: false
   },
+  isTestUser: {
+    type: Boolean,
+    default: false
+  },
 
   createdAt: {
     type: Date,


### PR DESCRIPTION
Test users will have an extra field that identify them as such: 
```javascript
// models/User.js
isTestUser: {
  type: Boolean,
  default: false
},
```

and if a new session is started by any of these users, no notification will be sent:
```javascript
// controllers/SessionCtrl.js
if (!user.isTestUser) {
   twilioService.notify(type, subTopic);
}
```

I already modified the documents of the official testing accounts in the live DB. @zuoyuanh @alymurray Make sure to update your local DB.