### PR TITLE
Feature/Time Zone

### DIFF
--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -50,6 +50,7 @@ module.exports = {
       }
       user.availability = availability;
       user.hasSchedule = true;
+      user.timezone = '';
       user.save(function(err, user){
         if (err){
           callback(err, null)
@@ -89,6 +90,38 @@ module.exports = {
           callback(null, availability)
         }
       });
+    });
+  },
+  updateTimezone: function(options, callback) {
+    var userid = options.userid;
+    var tz = options.tz;
+    User.findOne({_id: userid}, function(err, user){
+      if (err){
+        return callback(err);
+      }
+      if (!user) {
+        return callback(new Error('No account with that id found.'));
+      }
+      user.timezone = tz;
+      user.save(function(err, user){
+        if (err) {
+          callback(err, null);
+        } else {
+          callback(null, tz);
+        }
+      });
+    });
+  },
+  getTimezone: function(options, callback){
+    var userid = options.userid;
+    User.findOne({_id: userid}, function(err, user){
+      if (err){
+        return callback(err);
+      }
+      if (!user) {
+        return callback(new Error('No account with that id found.'));
+      }
+      callback(null, user.timezone);
     });
   }
 };

--- a/models/User.js
+++ b/models/User.js
@@ -96,6 +96,7 @@ var userSchema = new mongoose.Schema({
       '8p': Boolean, '9p': Boolean, '10p': Boolean, '11p': Boolean}
   },
   hasSchedule: false,
+  timezone: String,
 
   algebra: {
     passed: {

--- a/router/api/calendar.js
+++ b/router/api/calendar.js
@@ -34,5 +34,28 @@ module.exports = function(router){
         });
 			}
 		});
+	});
+	router.post('/calendar/tz/get', function(req, res){
+    CalendarCtrl.getTimezone({userid: req.body.userid}, function(err, tz){
+			if (err){
+				res.json({err: err});
+			} else {
+				res.json({
+          msg: 'Timezone retrieved',
+          tz: tz
+        });
+			}
+		});
+  });
+	router.post('/calendar/tz/save', function(req, res){
+    CalendarCtrl.updateTimezone({userid: req.body.userid, tz: req.body.tz}, function(err, tz){
+      if (err) {
+				res.json({err: err});
+			} else {
+				res.json({
+          msg: 'Timezone saved'
+        });
+			}
+		});
   });
 };

--- a/router/api/calendar.js
+++ b/router/api/calendar.js
@@ -1,61 +1,61 @@
 var CalendarCtrl = require('../../controllers/CalendarCtrl');
 
 module.exports = function(router){
-	router.post('/calendar/init', function(req, res){
+  router.post('/calendar/init', function(req, res){
     CalendarCtrl.initAvailability({userid: req.body.userid}, function(err){
-			if (err){
-				res.json({err: err});
-			} else {
-				res.json({
+      if (err){
+        res.json({err: err});
+      } else {
+        res.json({
           msg: 'Availability initialized'
         });
-			}
-		});
+      }
+    });
   });
   router.post('/calendar/get', function(req, res){
     CalendarCtrl.getAvailability({userid: req.body.userid}, function(err, availability){
-			if (err){
-				res.json({err: err});
-			} else {
-				res.json({
+      if (err){
+        res.json({err: err});
+      } else {
+        res.json({
           msg: 'Availability retrieved',
           availability: availability
         });
-			}
-		});
+      }
+    });
   });
   router.post('/calendar/save', function(req, res){
     CalendarCtrl.updateAvailability({userid: req.body.userid, availability: req.body.availability}, function(err, avail){
       if (err){
-				res.json({err: err});
-			} else {
-				res.json({
+        res.json({err: err});
+      } else {
+        res.json({
           msg: 'Availability saved'
         });
-			}
-		});
-	});
-	router.post('/calendar/tz/get', function(req, res){
+      }
+    });
+  });
+  router.post('/calendar/tz/get', function(req, res){
     CalendarCtrl.getTimezone({userid: req.body.userid}, function(err, tz){
-			if (err){
-				res.json({err: err});
-			} else {
-				res.json({
+      if (err){
+        res.json({err: err});
+      } else {
+        res.json({
           msg: 'Timezone retrieved',
           tz: tz
         });
-			}
-		});
+      }
+    });
   });
-	router.post('/calendar/tz/save', function(req, res){
+  router.post('/calendar/tz/save', function(req, res){
     CalendarCtrl.updateTimezone({userid: req.body.userid, tz: req.body.tz}, function(err, tz){
       if (err) {
-				res.json({err: err});
-			} else {
-				res.json({
+        res.json({err: err});
+      } else {
+        res.json({
           msg: 'Timezone saved'
         });
-			}
-		});
+      }
+    });
   });
 };


### PR DESCRIPTION
This PR allows user to choose their time zone for their availability calendar.

- Create a new field in mongodb schema which records the selection of timezone of the user, added API for updating and getting timezone user selected
- If the user has never selected any timezone before, the Vue frontend will automatically detect the timezone of the user
- All the availability are saved in EST in database. These time are converted to the time zone that user selected in Vue frontend when they are displayed to user.