### PR TITLE
Channel students back to active session

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -212,6 +212,15 @@ module.exports = {
     }
   },
 
+  findLatest: function(attrs, cb){
+    Session
+      .find(attrs)
+      .sort({ createdAt: -1 })
+      .limit(1)
+      .findOne()
+      .exec(cb);
+  },
+
   // Return all current socket sessions as array
   getSocketSessions: function(){
     return sessionManager.list();
@@ -252,7 +261,7 @@ module.exports = {
     var socket = options.socket;
 
     var user = sessionManager.getUserBySocket(socket);
-    
+
     var session = sessionManager.disconnect({
       socket: socket
     });

--- a/models/Session.js
+++ b/models/Session.js
@@ -40,6 +40,7 @@ var sessionSchema = new mongoose.Schema({
     type: Date,
     default: Date.now
   },
+
   endedAt: {
     type: Date
   }

--- a/models/Session.js
+++ b/models/Session.js
@@ -92,7 +92,7 @@ sessionSchema.methods.leaveUser = function(user, cb) {
 
 sessionSchema.methods.endSession = function(cb) {
   this.endedAt = new Date();
-  this.save(cb);
+  this.save(() => console.log(`Ended session ${this._id} at ${this.endedAt}`));
 };
 
 sessionSchema.methods.isActive = function(cb) {};

--- a/router/api/session.js
+++ b/router/api/session.js
@@ -24,7 +24,26 @@ module.exports = function(router){
 			});
 		});
 
-	router.route('/session/check')
+  router.route('/session/end')
+    .post(function(req, res){
+      var data = req.body || {},
+          sessionId = data.sessionId;
+
+      SessionCtrl.get({
+        sessionId: sessionId
+      }, function(err, session){
+        if (err){
+          res.json({err: err});
+        } else if (!session) {
+          res.json({err: 'No session found'});
+        } else {
+          session.endSession();
+          res.json({ sessionId: session._id });
+        }
+      });
+    });
+
+  router.route('/session/check')
 		.post(function(req, res){
 			var data = req.body || {},
 					sessionId = data.sessionId;

--- a/router/api/session.js
+++ b/router/api/session.js
@@ -66,4 +66,27 @@ module.exports = function(router){
 				}
 			});
 		});
+
+router
+  .route('/session/current')
+  .post(function(req, res){
+    const data = req.body || {};
+    const studentId = data.userId;
+
+    SessionCtrl
+      .findLatest(
+        { student: studentId, endedAt: null },
+        function(err, session){
+          if (err){
+            res.json({err: err});
+          } else if (!session) {
+            res.json({err: 'No session found'});
+          } else {
+            res.json({
+              sessionId: session._id,
+              data: session
+            });
+          }
+        });
+    });
 };


### PR DESCRIPTION
Adds `/session/end` and `/session/current` routes to the API. 

The former invokes `session.endSession` to persist the `endedAt` timestamp on the given session.

The latter finds the most recently created un-terminated session for the given student id using the `SessionController.findLatest` method introduced here.

Related: https://github.com/UPchieve/web/pull/153
https://app.asana.com/0/inbox/1108906145495473/1110715446927717/1110717696165263