### PR TITLE
Prevent two volunteers from joining the same session

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -117,6 +117,10 @@ SessionManager.prototype.disconnect = function(options){
 //
 // Return a reference to the SocketSession instance.
 SessionManager.prototype.pruneDeadSessions = () => {
+  if (!this._sessions) {
+    return this
+  }
+
   const sessionIds = Object.keys(this._sessions)
   const deadSessionIds =
         sessionIds

--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -114,31 +114,12 @@ SessionManager.prototype.disconnect = function(options){
 
 // A dead session is a session with no connected to it
 SessionManager.prototype.pruneDeadSessions = function(){
-
-  var activeSessions = Object.keys(this._sessions)
-    // Filter out inactive sessionIds
-    .filter(function(sessionId){
-      var socketSession = this._sessions[sessionId]
-      console.log(socketSession.session._id, 'socketSession.isDead() => ', socketSession.isDead())
-      return !socketSession.isDead();
-    }, this)
-    .map(function(activeSessionId){
-      return this._sessions[activeSessionId];
-    }, this);
-
-  // this._sessions is an Object indexed by session _id
-  const activeSessionsMap =
-        activeSessions
-        .reduce((acc, socketSession) => {
-          acc[socketSession.session._id] = socketSession
-          return acc
-        }, {})
-
-  this._sessions = activeSessionsMap;
+  const sessionIds = Object.keys(this._sessions)
+  const deadSessionIds = sessionIds.filter(sessionId => this._sessions[sessionId].isDead())
+  deadSessionIds.forEach(sessionId => delete this._sessions[sessionId])
 };
 
 SessionManager.prototype.list = function(){
-
   var sessions = this._sessions;
   return Object.keys(sessions).map(function(id){
     return sessions[id].session;

--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -126,13 +126,21 @@ SessionManager.prototype.pruneDeadSessions = function(){
       return this._sessions[activeSessionId];
     }, this);
 
-  this._sessions = activeSessions;
+  // this._sessions is an Object indexed by session _id
+  const activeSessionsMap =
+        activeSessions
+        .reduce((acc, socketSession) => {
+          acc[socketSession.session._id] = socketSession
+          return acc
+        }, {})
+
+  this._sessions = activeSessionsMap;
 };
 
 SessionManager.prototype.list = function(){
+
   var sessions = this._sessions;
   return Object.keys(sessions).map(function(id){
-    console.log(sessions[id].session);
     return sessions[id].session;
   });
 };

--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -112,12 +112,21 @@ SessionManager.prototype.disconnect = function(options){
   return session;
 }
 
-// A dead session is a session with no connected to it
-SessionManager.prototype.pruneDeadSessions = function(){
+// Delete any SocketSessions that are dead.
+// A dead session is a session with no users connected to it.
+//
+// Return a reference to the SocketSession instance.
+SessionManager.prototype.pruneDeadSessions = () => {
   const sessionIds = Object.keys(this._sessions)
-  const deadSessionIds = sessionIds.filter(sessionId => this._sessions[sessionId].isDead())
-  deadSessionIds.forEach(sessionId => delete this._sessions[sessionId])
-};
+  const deadSessionIds =
+        sessionIds
+        .filter(sessionId => this._sessions[sessionId].isDead())
+
+  deadSessionIds
+    .forEach(sessionId => delete this._sessions[sessionId])
+
+  return this
+}
 
 SessionManager.prototype.list = function(){
   var sessions = this._sessions;


### PR DESCRIPTION
This resolves the underlying issue causing https://github.com/UPchieve/web/issues/134.

Fixes: https://github.com/UPchieve/web/issues/134
Related: https://app.asana.com/0/775116702697292/1107635562909714

The session list is initialized as an Object and it's meant to index SocketSession objects by the id of the attached Session object:

```js
// controllers/SessionCtrl.js L68-70 

var SessionManager = function(){
  this._sessions = {}; // id => SocketSession
};
```
```js
// controllers/SessionCtrl.js L6-11 

// A socket session tracks a session with its users and sockets
var SocketSession = function(options){
  this.session = options.session;
  this.users = []; // [User]
  this.sockets = {}; // userId => socket
};
```
but `this._sessions` is overwritten with an Array when `pruneDeadSessions` is invoked:

```js
// controllers/SessionCtrl.js L115-130 

// A dead session is a session with no connected to it
SessionManager.prototype.pruneDeadSessions = function(){

  var activeSessions = Object.keys(this._sessions)
    // Filter out inactive sessionIds
    .filter(function(sessionId){
      var socketSession = this._sessions[sessionId]
      console.log(socketSession.session._id, 'socketSession.isDead() => ', socketSession.isDead())
      return !socketSession.isDead();
    }, this)
    .map(function(activeSessionId){
      return this._sessions[activeSessionId];
    }, this);

  this._sessions = activeSessions;
};
```

After a student starts a session, `this._sessions` is emitted to the `ListSessions` component containing a session:

``` 
// JS console: ListSessions.vue

[{
  session_id: "5c8027acedcbfd50d2c50df2",
  student: "5c7d4d83e4c1f38bc421bae8",
  volunteer: undefined
}]
```

After the first volunteer joins a session, the following is emitted (note the dupe session_id):

```
[
{session_id: "5c8027acedcbfd50d2c50df2", student: "5c7d4d83e4c1f38bc421bae8", volunteer: undefined},
{session_id: "5c8027acedcbfd50d2c50df2", student: "5c7d4d83e4c1f38bc421bae8", volunteer: "5c7d4d83e4c1f38bc421baea"}
]
```

See https://github.com/UPchieve/server/pull/71#discussion_r263062951 for more discussion.



### Demos

(click to enlarge)

#### Before

![before](https://user-images.githubusercontent.com/4433943/53904258-9cc19780-4013-11e9-9ec7-9bd6250f69d1.gif)


#### After

![after](https://user-images.githubusercontent.com/4433943/53904252-992e1080-4013-11e9-80dd-929dee362cca.gif)

### Dev box testing

![dev box](https://user-images.githubusercontent.com/4433943/53919519-3f8c0d00-4038-11e9-8d85-731800f5cf35.gif)
