### PR TITLE
Add validators to User model

### DIFF
--- a/controllers/UserCtrl.js
+++ b/controllers/UserCtrl.js
@@ -62,7 +62,7 @@ module.exports = {
       return callback('No fields defined to update')
     }
 
-    User.findByIdAndUpdate(userId, update, { new: true }, function (err, user) {
+    User.findByIdAndUpdate(userId, update, { new: true, runValidators: true }, function (err, user) {
       if (err) {
         return callback(err)
       } else {

--- a/models/User.js
+++ b/models/User.js
@@ -42,11 +42,10 @@ var userSchema = new mongoose.Schema({
      type: String,
      validate: {
        validator: function(v) {
-         // see http://regexlib.com/REDetails.aspx?regexp_id=58
-         var re = /^([0-9]( |-)?)?(\(?[0-9]{3}\)?|[0-9]{3})( |-)?([0-9]{3}( |-)?[0-9]{4}|[a-zA-Z0-9]{7})$/;
+         var re = /^[0-9]{3}-[0-9]{3}-[0-9]{4}$/;
          return re.test(v);
        },
-       message: '{VALUE} is not a valid U.S. phone number'
+       message: '{VALUE} is not a phone number in the format ###-###-####'
      }
   },
   highschool: String,

--- a/models/User.js
+++ b/models/User.js
@@ -38,7 +38,17 @@ var userSchema = new mongoose.Schema({
   groupIdentification: [String],
   computerAccess: [String],
   preferredTimes: [String],
-  phone: String,
+  phone: { 
+     type: String,
+     validate: {
+       validator: function(v) {
+         // see http://regexlib.com/REDetails.aspx?regexp_id=58
+         var re = /^([0-9]( |-)?)?(\(?[0-9]{3}\)?|[0-9]{3})( |-)?([0-9]{3}( |-)?[0-9]{4}|[a-zA-Z0-9]{7})$/;
+         return re.test(v);
+       },
+       message: '{VALUE} is not a valid U.S. phone number'
+     }
+  },
   highschool: String,
   currentGrade: String,
   expectedGraduation: String,

--- a/models/User.js
+++ b/models/User.js
@@ -27,8 +27,8 @@ var userSchema = new mongoose.Schema({
   passwordResetToken: String,
 
   // Profile data
-  firstname: String,
-  lastname: String,
+  firstname: { type: String, required: [true, 'First name is required.'] },
+  lastname: { type: String, required: [true, 'Last name is required.'] },
   nickname: String,
   serviceInterests: [String],
   picture: String,
@@ -46,20 +46,22 @@ var userSchema = new mongoose.Schema({
          return re.test(v);
        },
        message: '{VALUE} is not a phone number in the format ###-###-####'
-     }
+     },
+     required: [function() { return this.isVolunteer; }, 'Phone number is required.']
   },
-  highschool: String,
+  highschool: { type: String, required: [function() { return !this.isVolunteer; }, 'High school is required.'] },
   currentGrade: String,
   expectedGraduation: String,
   difficultAcademicSubject: String,
   difficultCollegeProcess: [String],
   highestLevelEducation: [String],
   hasGuidanceCounselor: String,
-  favoriteAcademicSubject: String,
+  favoriteAcademicSubject: { type: String, required: [function() { return this.isVolunteer; }, 
+      'Favorite academic subject is required']},
   gpa: String,
   collegeApplicationsText: String,
   commonCollegeDocs: [String],
-  college: String,
+  college: { type: String, required: [function() { return this.isVolunteer; }, 'College is required.'] },
   academicInterestsText: String,
   testScoresText: String,
   advancedCoursesText: String,

--- a/router/auth/index.js
+++ b/router/auth/index.js
@@ -131,6 +131,13 @@ module.exports = function (app) {
 
     var lastName = req.body.lastName
     
+    var terms = req.body.terms;
+    
+    if (!terms) {
+      return res.json({
+        err: 'Must accept the user agreement'
+      })
+    }
 
     if (!email || !password) {
       return res.json({

--- a/router/auth/index.js
+++ b/router/auth/index.js
@@ -126,6 +126,12 @@ module.exports = function (app) {
     var code = req.body.code
 
     var highSchool = req.body.highSchool
+    
+    var college = req.body.college
+    
+    var phone = req.body.phone
+    
+    var favoriteAcademicSubject = req.body.favoriteAcademicSubject
 
     var firstName = req.body.firstName
 
@@ -158,6 +164,9 @@ module.exports = function (app) {
     user.isVolunteer = !(code === undefined)
     user.registrationCode = code
     user.highschool = highSchool
+    user.college = college
+    user.phone = phone
+    user.favoriteAcademicSubject = favoriteAcademicSubject
     user.firstname = firstName
     user.lastname = lastName
     user.verified = code === undefined

--- a/router/auth/index.js
+++ b/router/auth/index.js
@@ -10,6 +10,7 @@ var ResetPasswordCtrl = require('../../controllers/ResetPasswordCtrl')
 var config = require('../../config.js')
 var User = require('../../models/User.js')
 
+// Validation functions
 function checkPassword (password) {
   if (password.length < 8) {
     return 'Password must be 8 characters or longer'
@@ -129,6 +130,7 @@ module.exports = function (app) {
     var firstName = req.body.firstName
 
     var lastName = req.body.lastName
+    
 
     if (!email || !password) {
       return res.json({
@@ -143,9 +145,9 @@ module.exports = function (app) {
         err: checkResult
       })
     }
-
+    
     var user = new User()
-    user.email = email
+    user.email = email    
     user.isVolunteer = !(code === undefined)
     user.registrationCode = code
     user.highschool = highSchool


### PR DESCRIPTION
https://www.notion.so/upchieve/6abe4da08ab045eea31efb13148448d6?v=1d1d833174ef402195a1d75586a1356d&p=ec4963f6260545dab3f6cfb3c95db045

I've added a validator to the phone field that accepts numbers only in the strict format ###-###-####. This is intended to make all phone records in the database consistent in form; the client can accept phone numbers in other formats and convert them so the server accepts it.

I have also now added appropriate "required" validators to the User model for fields that are required on signup, so that the document will only save if those fields are defined and non-null.

Also, I added a check in the registration handler that prevents addition of the user to the database if they did not accept the user agreement.

Fields that are required on signup are now sent to auth/register instead of api/user, so that they can be verified before the user is saved in the database.