### PR TITLE
Show indicator when other user is typing in chat

### DIFF
--- a/router/api/sockets.js
+++ b/router/api/sockets.js
@@ -75,6 +75,15 @@ module.exports = function (app) {
       io.emit('sessions', SessionCtrl.getSocketSessions())
     })
 
+    socket.on('typing', function (data) {
+      //TODO: handle typing
+    })
+
+    socket.on('notTyping', function (data) {
+      //TODO: handle not typing
+    })
+
+
     socket.on('message', function (data) {
       if (!data.sessionId) return
 

--- a/router/api/sockets.js
+++ b/router/api/sockets.js
@@ -76,11 +76,11 @@ module.exports = function (app) {
     })
 
     socket.on('typing', function (data) {
-      //TODO: handle typing
+      socket.broadcast.to(data.sessionId).emit('is-typing')
     })
 
     socket.on('notTyping', function (data) {
-      //TODO: handle not typing
+      socket.broadcast.to(data.sessionId).emit('not-typing')
     })
 
 

--- a/router/api/sockets.js
+++ b/router/api/sockets.js
@@ -76,7 +76,7 @@ module.exports = function (app) {
     })
 
     socket.on('typing', function (data) {
-      socket.broadcast.to(data.sessionId).emit('is-typing')
+      socket.broadcast.to(data.sessionId).emit('is-typing', data.user.firstname)
     })
 
     socket.on('notTyping', function (data) {


### PR DESCRIPTION
Links
-----
Task: https://www.notion.so/upchieve/Let-session-participants-know-other-participant-is-typing-28a5788755cf41a797ab4009ce09e984

Related PRs: https://github.com/UPchieve/web/pull/180 (front end for the task)

Description
-----------
Added two socket receivers, `typing` and `notTyping` that broadcast to the other user's client the status of typing so that indicators can be updated.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] PR link has been posted in the task's comments
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] Task and PR have been updated to show that this is ready for review
