### PR TITLE
Format phone numbers

### DIFF
--- a/controllers/UserCtrl.js
+++ b/controllers/UserCtrl.js
@@ -1,5 +1,17 @@
 var User = require('../models/User')
 
+// helper to respond to errors
+
+function getProfileIfSuccessful(callback) {
+  return function (err, user) {
+    if (err) {
+      return callback(err)
+    } else {
+      user.getProfile(callback)
+    }
+  }
+}
+
 module.exports = {
   get: function (options, callback) {
     var userId = options.userId
@@ -19,55 +31,83 @@ module.exports = {
     var update = {}
 
     var hasUpdate = false
-    // Define and iterate through keys to add to update object
 
-    ;[
-      'firstname',
-      'lastname',
-      'nickname',
-      'picture',
-      'birthdate',
-      'serviceInterests',
-      'gender',
-      'race',
-      'groupIdentification',
-      'computerAccess',
-      'preferredTimes',
-      'phone',
-      'highschool',
-      'currentGrade',
-      'expectedGraduation',
-      'difficultAcademicSubject',
-      'difficultCollegeProcess',
-      'highestLevelEducation',
-      'hasGuidanceCounselor',
-      'gpa',
-      'college',
-      'collegeApplicationsText',
-      'commonCollegeDocs',
-      'academicInterestsText',
-      'testScoresText',
-      'advancedCoursesText',
-      'favoriteAcademicSubject',
-      'extracurricularActivitesText',
-      'referred',
-      'heardFrom'
-    ].forEach(function (key) {
-      if (data[key]) {
-        update[key] = data[key]
-        hasUpdate = true
-      }
-    })
-    if (!hasUpdate) {
-      return callback('No fields defined to update')
+    // Keys to virtual properties
+    var virtualProps = ['phonePretty']
+    if (virtualProps.some(function (key) { return data[key] })) {
+      // load model object into memory
+      User.findById(userId, function (err, user) {
+        if (err) {
+          callback(err)
+        }
+        else {
+          if (!user) {
+            update = new User()
+          }
+          else {
+            update = user
+          }
+          iterateKeysAndUpdate()
+        }
+      })
+    }
+    else {
+      iterateKeysAndUpdate()
     }
 
-    User.findByIdAndUpdate(userId, update, { new: true, runValidators: true }, function (err, user) {
-      if (err) {
-        return callback(err)
-      } else {
-        user.getProfile(callback)
+    // Define and iterate through keys to add to update object
+    var iterateKeysAndUpdate = function () {
+      ;[
+        'firstname',
+        'lastname',
+        'nickname',
+        'picture',
+        'birthdate',
+        'serviceInterests',
+        'gender',
+        'race',
+        'groupIdentification',
+        'computerAccess',
+        'preferredTimes',
+        'phone',
+        'highschool',
+        'currentGrade',
+        'expectedGraduation',
+        'difficultAcademicSubject',
+        'difficultCollegeProcess',
+        'highestLevelEducation',
+        'hasGuidanceCounselor',
+        'gpa',
+        'college',
+        'collegeApplicationsText',
+        'commonCollegeDocs',
+        'academicInterestsText',
+        'testScoresText',
+        'advancedCoursesText',
+        'favoriteAcademicSubject',
+        'extracurricularActivitesText',
+        'referred',
+        'heardFrom',
+        'phonePretty'
+      ].forEach(function (key) {
+        if (data[key]) {
+          update[key] = data[key]
+          hasUpdate = true
+        }
+      })
+
+      if (!hasUpdate) {
+        return callback('No fields defined to update')
       }
-    })
+
+      if (virtualProps.some(function (key) { return data[key] })) {
+        // save the model that was loaded into memory
+        update.save(getProfileIfSuccessful(callback))
+      }
+      else {
+        // update the model (more efficient, but ignores virtual props)
+        User.findByIdAndUpdate(userId, update, { new: true, runValidators: true }, getProfileIfSuccessful(callback))
+      }
+    }
   }
 }

--- a/controllers/UserCtrl.js
+++ b/controllers/UserCtrl.js
@@ -1,14 +1,63 @@
 var User = require('../models/User')
 
-// helper to respond to errors
-
-function getProfileIfSuccessful(callback) {
+// helper to check for errors before getting user profile
+function getProfileIfSuccessful (callback) {
   return function (err, user) {
     if (err) {
       return callback(err)
     } else {
       user.getProfile(callback)
     }
+  }
+}
+
+// helper to iterate through keys to be added to an update object
+function iterateKeys (update, data, callback) {
+  var hasUpdate = false
+
+  ;[
+    'firstname',
+    'lastname',
+    'nickname',
+    'picture',
+    'birthdate',
+    'serviceInterests',
+    'gender',
+    'race',
+    'groupIdentification',
+    'computerAccess',
+    'preferredTimes',
+    'phone',
+    'highschool',
+    'currentGrade',
+    'expectedGraduation',
+    'difficultAcademicSubject',
+    'difficultCollegeProcess',
+    'highestLevelEducation',
+    'hasGuidanceCounselor',
+    'gpa',
+    'college',
+    'collegeApplicationsText',
+    'commonCollegeDocs',
+    'academicInterestsText',
+    'testScoresText',
+    'advancedCoursesText',
+    'favoriteAcademicSubject',
+    'extracurricularActivitesText',
+    'referred',
+    'heardFrom',
+    'phonePretty'
+  ].forEach(function (key) {
+    if (data[key]) {
+      update[key] = data[key]
+      hasUpdate = true
+    }
+  })
+
+  if (!hasUpdate) {
+    callback('No fields defined to update')
+  } else {
+    callback(null, update)
   }
 }
 
@@ -30,84 +79,37 @@ module.exports = {
 
     var update = {}
 
-    var hasUpdate = false
-
-    // Define and iterate through keys to add to update object
-    var iterateKeysAndUpdate = function () {
-      ;[
-        'firstname',
-        'lastname',
-        'nickname',
-        'picture',
-        'birthdate',
-        'serviceInterests',
-        'gender',
-        'race',
-        'groupIdentification',
-        'computerAccess',
-        'preferredTimes',
-        'phone',
-        'highschool',
-        'currentGrade',
-        'expectedGraduation',
-        'difficultAcademicSubject',
-        'difficultCollegeProcess',
-        'highestLevelEducation',
-        'hasGuidanceCounselor',
-        'gpa',
-        'college',
-        'collegeApplicationsText',
-        'commonCollegeDocs',
-        'academicInterestsText',
-        'testScoresText',
-        'advancedCoursesText',
-        'favoriteAcademicSubject',
-        'extracurricularActivitesText',
-        'referred',
-        'heardFrom',
-        'phonePretty'
-      ].forEach(function (key) {
-        if (data[key]) {
-          update[key] = data[key]
-          hasUpdate = true
-        }
-      })
-
-      if (!hasUpdate) {
-        return callback('No fields defined to update')
-      }
-
-      if (virtualProps.some(function (key) { return data[key] })) {
-        // save the model that was loaded into memory
-        update.save(getProfileIfSuccessful(callback))
-      }
-      else {
-        // update the model (more efficient, but ignores virtual props)
-        User.findByIdAndUpdate(userId, update, { new: true, runValidators: true }, getProfileIfSuccessful(callback))
-      }
-    }
-
     // Keys to virtual properties
     var virtualProps = ['phonePretty']
+
     if (virtualProps.some(function (key) { return data[key] })) {
       // load model object into memory
       User.findById(userId, function (err, user) {
         if (err) {
           callback(err)
-        }
-        else {
+        } else {
           if (!user) {
             update = new User()
-          }
-          else {
+          } else {
             update = user
           }
-          iterateKeysAndUpdate()
+          iterateKeys(update, data, function (err, update) {
+            if (err) {
+              return callback(err)
+            }
+            // save the model that was loaded into memory, processing the virtuals
+            update.save(getProfileIfSuccessful(callback))
+          })
         }
       })
-    }
-    else {
-      iterateKeysAndUpdate()
+    } else {
+      iterateKeys(update, data, function (err, update) {
+        if (err) {
+          return callback('No fields defined to update')
+        }
+        // update the document directly (more efficient, but ignores virtual props)
+        User.findByIdAndUpdate(userId, update, { new: true, runValidators: true }, getProfileIfSuccessful(callback))
+      })
     }
   }
 }

--- a/controllers/UserCtrl.js
+++ b/controllers/UserCtrl.js
@@ -32,29 +32,6 @@ module.exports = {
 
     var hasUpdate = false
 
-    // Keys to virtual properties
-    var virtualProps = ['phonePretty']
-    if (virtualProps.some(function (key) { return data[key] })) {
-      // load model object into memory
-      User.findById(userId, function (err, user) {
-        if (err) {
-          callback(err)
-        }
-        else {
-          if (!user) {
-            update = new User()
-          }
-          else {
-            update = user
-          }
-          iterateKeysAndUpdate()
-        }
-      })
-    }
-    else {
-      iterateKeysAndUpdate()
-    }
-
     // Define and iterate through keys to add to update object
     var iterateKeysAndUpdate = function () {
       ;[
@@ -108,6 +85,29 @@ module.exports = {
         // update the model (more efficient, but ignores virtual props)
         User.findByIdAndUpdate(userId, update, { new: true, runValidators: true }, getProfileIfSuccessful(callback))
       }
+    }
+
+    // Keys to virtual properties
+    var virtualProps = ['phonePretty']
+    if (virtualProps.some(function (key) { return data[key] })) {
+      // load model object into memory
+      User.findById(userId, function (err, user) {
+        if (err) {
+          callback(err)
+        }
+        else {
+          if (!user) {
+            update = new User()
+          }
+          else {
+            update = user
+          }
+          iterateKeysAndUpdate()
+        }
+      })
+    }
+    else {
+      iterateKeysAndUpdate()
     }
   }
 }

--- a/models/User.js
+++ b/models/User.js
@@ -500,7 +500,7 @@ userSchema.virtual('phonePretty')
     // see http://regexlib.com/REDetails.aspx?regexp_id=58
     // modified to ignore trailing/leading whitespace and disallow alphanumeric characters
     var re = /^\s*(?:[0-9](?: |-)?)?(?:\(?([0-9]{3})\)?|[0-9]{3})(?: |-)?(?:([0-9]{3})(?: |-)?([0-9]{4}))\s*$/
-    var [, area, prefix, line] = v.match(re)
+    var [, area, prefix, line] = v.match(re) || []
     this.phone = `${area}${prefix}${line}`
   })
 

--- a/models/User.js
+++ b/models/User.js
@@ -388,6 +388,15 @@ var userSchema = new mongoose.Schema({
     type: Date,
     default: Date.now
   }
+},
+{
+  toJSON: {
+    virtuals: true
+  },
+
+  toObject: {
+    virtuals: true
+  }
 })
 
 // Given a user record, strip out sensitive data for public consumption
@@ -477,7 +486,7 @@ userSchema.methods.verifyPassword = function (candidatePassword, cb) {
 userSchema.virtual('phonePretty')
   .get(function () {
     var re = /^([0-9]{3})([0-9]{3})([0-9]{4})$/
-    var [ , area, prefix, line] = this.phone.match(re)
+    var [, area, prefix, line] = this.phone.match(re)
     return `${area}-${prefix}-${line}`
   })
   .set(function (v) {
@@ -485,7 +494,7 @@ userSchema.virtual('phonePretty')
     // see http://regexlib.com/REDetails.aspx?regexp_id=58
     // modified to ignore trailing/leading whitespace and disallow alphanumeric characters
     var re = /^\s*(?:[0-9](?: |-)?)?(?:\(?([0-9]{3})\)?|[0-9]{3})(?: |-)?(?:([0-9]{3})(?: |-)?([0-9]{4}))\s*$/
-    var [ , area, prefix, line] = v.match(re)
+    var [, area, prefix, line] = v.match(re)
     this.phone = `${area}${prefix}${line}`
   })
 

--- a/models/User.js
+++ b/models/User.js
@@ -449,7 +449,9 @@ userSchema.methods.parseProfile = function () {
     trigonometry: this.trigonometry,
     esl: this.esl,
     precalculus: this.precalculus,
-    calculus: this.calculus
+    calculus: this.calculus,
+
+    phonePretty: this.phonePretty
   }
 }
 

--- a/models/User.js
+++ b/models/User.js
@@ -38,30 +38,27 @@ var userSchema = new mongoose.Schema({
   groupIdentification: [String],
   computerAccess: [String],
   preferredTimes: [String],
-  phone: { 
-     type: String,
-     validate: {
-       validator: function(v) {
-         var re = /^[0-9]{3}-[0-9]{3}-[0-9]{4}$/;
-         return re.test(v);
-       },
-       message: '{VALUE} is not a phone number in the format ###-###-####'
-     },
-     required: [function() { return this.isVolunteer; }, 'Phone number is required.']
+  phone: {
+    type: String,
+    match: [ /^[0-9]{10}$/, '{VALUE} is not a phone number in the format ##########' ],
+    required: [function () { return this.isVolunteer }, 'Phone number is required.']
   },
-  highschool: { type: String, required: [function() { return !this.isVolunteer; }, 'High school is required.'] },
+
+  highschool: { type: String, required: [function () { return !this.isVolunteer }, 'High school is required.'] },
   currentGrade: String,
   expectedGraduation: String,
   difficultAcademicSubject: String,
   difficultCollegeProcess: [String],
   highestLevelEducation: [String],
   hasGuidanceCounselor: String,
-  favoriteAcademicSubject: { type: String, required: [function() { return this.isVolunteer; }, 
-      'Favorite academic subject is required']},
+  favoriteAcademicSubject: {
+    type: String,
+    required: [function () { return this.isVolunteer }, 'Favorite academic subject is required']
+  },
   gpa: String,
   collegeApplicationsText: String,
   commonCollegeDocs: [String],
-  college: { type: String, required: [function() { return this.isVolunteer; }, 'College is required.'] },
+  college: { type: String, required: [function () { return this.isVolunteer }, 'College is required.'] },
   academicInterestsText: String,
   testScoresText: String,
   advancedCoursesText: String,
@@ -475,6 +472,22 @@ userSchema.methods.verifyPassword = function (candidatePassword, cb) {
     }
   })
 }
+
+// virtual type for phone number formatted for readability
+userSchema.virtual('phonePretty')
+  .get(function () {
+    var re = /^([0-9]{3})([0-9]{3})([0-9]{4})$/
+    var [ , area, prefix, line] = this.phone.match(re)
+    return `${area}-${prefix}-${line}`
+  })
+  .set(function (v) {
+    // regular expression that accepts multiple valid U. S. phone number formats
+    // see http://regexlib.com/REDetails.aspx?regexp_id=58
+    // modified to ignore trailing/leading whitespace and disallow alphanumeric characters
+    var re = /^\s*(?:[0-9](?: |-)?)?(?:\(?([0-9]{3})\)?|[0-9]{3})(?: |-)?(?:([0-9]{3})(?: |-)?([0-9]{4}))\s*$/
+    var [ , area, prefix, line] = v.match(re)
+    this.phone = `${area}${prefix}${line}`
+  })
 
 // Static method to determine if a registration code is valid
 userSchema.statics.checkCode = function (code, cb) {

--- a/models/User.js
+++ b/models/User.js
@@ -487,6 +487,10 @@ userSchema.methods.verifyPassword = function (candidatePassword, cb) {
 // virtual type for phone number formatted for readability
 userSchema.virtual('phonePretty')
   .get(function () {
+    if (!this.phone) {
+      return null
+    }
+
     var re = /^([0-9]{3})([0-9]{3})([0-9]{4})$/
     var [, area, prefix, line] = this.phone.match(re)
     return `${area}-${prefix}-${line}`

--- a/router/api/user.js
+++ b/router/api/user.js
@@ -30,7 +30,7 @@ module.exports = function (router) {
           groupIdentification: data.groupIdentification,
           computerAccess: data.computerAccess,
           preferredTimes: data.preferredTimes,
-          phone: data.phone,
+          phonePretty: data.phonePretty,
           highschool: data.highschool,
           currentGrade: data.currentGrade,
           expectedGraduation: data.expectedGraduation,

--- a/router/api/user.js
+++ b/router/api/user.js
@@ -30,6 +30,7 @@ module.exports = function (router) {
           groupIdentification: data.groupIdentification,
           computerAccess: data.computerAccess,
           preferredTimes: data.preferredTimes,
+          phone: data.phone,
           phonePretty: data.phonePretty,
           highschool: data.highschool,
           currentGrade: data.currentGrade,

--- a/router/auth/index.js
+++ b/router/auth/index.js
@@ -126,19 +126,19 @@ module.exports = function (app) {
     var code = req.body.code
 
     var highSchool = req.body.highSchool
-    
+
     var college = req.body.college
-    
+
     var phone = req.body.phone
-    
+
     var favoriteAcademicSubject = req.body.favoriteAcademicSubject
 
     var firstName = req.body.firstName
 
     var lastName = req.body.lastName
-    
-    var terms = req.body.terms;
-    
+
+    var terms = req.body.terms
+
     if (!terms) {
       return res.json({
         err: 'Must accept the user agreement'
@@ -158,14 +158,14 @@ module.exports = function (app) {
         err: checkResult
       })
     }
-    
+
     var user = new User()
-    user.email = email    
+    user.email = email
     user.isVolunteer = !(code === undefined)
     user.registrationCode = code
     user.highschool = highSchool
     user.college = college
-    user.phone = phone
+    user.phonePretty = phone
     user.favoriteAcademicSubject = favoriteAcademicSubject
     user.firstname = firstName
     user.lastname = lastName


### PR DESCRIPTION
Links
-----
Task: https://www.notion.so/upchieve/Store-phone-number-in-format-accepted-by-Twilio-5ab9c42e48f54325aaee7fec063d1ff3

Related PRs: https://github.com/UPchieve/web/pull/185, https://github.com/UPchieve/server/pull/92, https://github.com/UPchieve/server/pull/100

Description
-----------
My previous PR for validating the signup fields decided on storing the phone numbers in a commonly-used and nicely-readable format, ###-###-####. However, after some discussion we realized that this number would invalidate calls to Twilio's API: https://github.com/UPchieve/server/pull/92#issuecomment-506854462.

This PR uses mongoose's concept of "virtual properties" to ensure that phone numbers are stored in the database in the original 10-digit format without hyphens, and sends them to Twilio in the format they need, while providing an interface for functions to read and set phone numbers in other valid U. S. formats. This way, we can ensure that our call to Twilio is valid regardless of the phone number format that users decide on.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] PR link has been posted in the task's comments
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] Task and PR have been updated to show that this is ready for review
