### PR TITLE
Saving topic and subtopic in stored feedbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,8 @@ Possible errors:
 
 ```json
 {
-  "sessionType": "String",
-  "sessionSubTopic": "String"
+  "type": "String",
+  "subTopic": "String"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ Possible errors:
 
 ```json
 {
-  "type": "String",
-  "subTopic": "String"
+  "sessionType": "String",
+  "sessionSubTopic": "String"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ Possible errors:
 ```json
 {
   "sessionId": "String",
+  "topic": "String",
+  "subTopic": "String",
   "responseData": "String"
 }
 ```

--- a/models/Feedback.js
+++ b/models/Feedback.js
@@ -6,7 +6,7 @@ var feedbackSchema = new mongoose.Schema({
     default: ''
   },
 
-  topic: {
+  type: {
     type: String,
     default: ''
   },

--- a/models/Feedback.js
+++ b/models/Feedback.js
@@ -6,6 +6,16 @@ var feedbackSchema = new mongoose.Schema({
     default: ''
   },
 
+  topic: {
+    type: String,
+    default: ''
+  },
+
+  subTopic: {
+    type: String,
+    default: ''
+  },
+  
   responseData: {
     type: Object,
     default: ''

--- a/router/api/feedback.js
+++ b/router/api/feedback.js
@@ -5,6 +5,8 @@ module.exports = function (router) {
     var body = req.body
     var feedback = new Feedback({
       sessionId: body['sessionId'],
+      topic: body['topic'],
+      subTopic: body['subTopic'],
       responseData: body['responseData'],
       userType: body['userType'],
       studentId: body['studentId'],

--- a/router/api/feedback.js
+++ b/router/api/feedback.js
@@ -5,7 +5,7 @@ module.exports = function (router) {
     var body = req.body
     var feedback = new Feedback({
       sessionId: body['sessionId'],
-      topic: body['topic'],
+      type: body['topic'],
       subTopic: body['subTopic'],
       responseData: body['responseData'],
       userType: body['userType'],


### PR DESCRIPTION
Links
-----
Task: https://www.notion.so/upchieve/Add-the-subtopic-answered-in-volunteer-feedback-form-e593fd18c32644a2b3e2a85591241513

Related PRs: https://github.com/UPchieve/web/pull/187


Description
-----------
Feedback form now saves the session topic and subtopic in database. User does not manually enter this information.


Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] PR link has been posted in the task's comments
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] Task and PR have been updated to show that this is ready for review
