### PR TITLE
Entering Email for Password Reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ Possible errors:
 ```json
 {
   "sessionId": "String",
+  "topic": "String",
+  "subTopic": "String",
   "responseData": "String"
 }
 ```

--- a/controllers/ResetPasswordCtrl.js
+++ b/controllers/ResetPasswordCtrl.js
@@ -57,7 +57,6 @@ module.exports = {
   },
 
   finishReset: function (options, callback) {
-    var email = options.email
     var token = options.token
 
     async.waterfall(
@@ -71,10 +70,6 @@ module.exports = {
               )
             } else if (err) {
               return done(err)
-            } else if (user.email !== email) {
-              return done(
-                new Error('Email did not match the password reset token')
-              )
             }
             done(null, user)
           })

--- a/models/Feedback.js
+++ b/models/Feedback.js
@@ -6,6 +6,16 @@ var feedbackSchema = new mongoose.Schema({
     default: ''
   },
 
+  topic: {
+    type: String,
+    default: ''
+  },
+
+  subTopic: {
+    type: String,
+    default: ''
+  },
+  
   responseData: {
     type: Object,
     default: ''

--- a/router/api/feedback.js
+++ b/router/api/feedback.js
@@ -5,6 +5,8 @@ module.exports = function (router) {
     var body = req.body
     var feedback = new Feedback({
       sessionId: body['sessionId'],
+      topic: body['topic'],
+      subTopic: body['subTopic'],
       responseData: body['responseData'],
       userType: body['userType'],
       studentId: body['studentId'],

--- a/router/auth/index.js
+++ b/router/auth/index.js
@@ -289,7 +289,7 @@ module.exports = function (app) {
   })
 
   router.post('/reset/confirm', function (req, res) {
-    var email = req.body.email
+    
 
     var password = req.body.password
 
@@ -301,9 +301,9 @@ module.exports = function (app) {
       return res.json({
         err: 'No password reset token given'
       })
-    } else if (!email || !password) {
+    } else if (!password) {
       return res.json({
-        err: 'Must supply an email and password for password reset'
+        err: 'Must supply a password for password reset'
       })
     } else if (!newpassword) {
       return res.json({

--- a/services/MailService.js
+++ b/services/MailService.js
@@ -49,7 +49,7 @@ module.exports = {
   sendVerification: function (options, callback) {
     var email = options.email
     var token = options.token
-    var url = 'http://' + config.client.host + '/#/action/verify/' + token
+    var url = 'http://' + config.client.host + '/action/verify/' + token
     console.log(url)
 
     var mail = getMailHelper({

--- a/services/MailService.js
+++ b/services/MailService.js
@@ -71,7 +71,7 @@ module.exports = {
   sendReset: function (options, callback) {
     var email = options.email
     var token = options.token
-    var url = 'http://' + config.client.host + '/#/setpassword/' + token
+    var url = 'http://' + config.client.host + '/setpassword/' + token
 
     var emailContent = [
       'Click on this link to choose a new password!',


### PR DESCRIPTION
Links
-----
Task: https://www.notion.so/upchieve/2-issues-with-reset-password-link-user-input-email-643910b97c9f41608c3abe4446ccde4c

Description
-----------
Two Bugs, but the server-related one is 1 and changed on web side for 2. 
1. After user received the reset password email, they needed to re-input their email. No need for this because already sending verification token which, according to standard reset password practices, is secure enough. Instead only uses token to identify user, and then updates password given that.
2. There were to instances when the password needs to be reset: when the password is forgotten so you cannot login or when the user would like to change their password. These instances should be treated differently, for the user should not have to re-input their email if they are already logged in. Changed to only allowing user to input email if no user is logged in.

Important!: Also got rid of # signs that were in both volunteer verification emails and password reset emails. This is crucial, for as of now users are not receiving valid links via email.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] PR link has been posted in the task's comments
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] Task and PR have been updated to show that this is ready for review
