### PR TITLE
Autocorrect phone number in database when getter is accessed.

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -484,6 +484,8 @@ userSchema.methods.verifyPassword = function (candidatePassword, cb) {
   })
 }
 
+const PHONE_REGEX = /^\s*(?:[0-9](?: |-)?)?(?:\(?([0-9]{3})\)?|[0-9]{3})(?: |-)?(?:([0-9]{3})(?: |-)?([0-9]{4}))\s*$/
+
 // virtual type for phone number formatted for readability
 userSchema.virtual('phonePretty')
   .get(function () {
@@ -491,16 +493,34 @@ userSchema.virtual('phonePretty')
       return null
     }
 
-    var re = /^([0-9]{3})([0-9]{3})([0-9]{4})$/
-    var [, area, prefix, line] = this.phone.match(re)
+    // first test user's phone number to see if it's a valid U.S. phone numer
+    var matches = this.phone.match(PHONE_REGEX)
+    if (!matches) {
+      return null
+    }
+
+    var [, area, prefix, line] = matches
+    // accepted phone number format in database
+    var reStrict = /^([0-9]{3})([0-9]{3})([0-9]{4})$/
+    if (!this.phone.match(reStrict)) {
+      // autocorrect phone number format
+      var oldPhone = this.phone
+      this.phone = `${area}${prefix}${line}`
+      this.save(function (err, newPhone) {
+        if (err) {
+          console.log(err)
+        } else {
+          console.log(`Phone number ${oldPhone} corrected to ${newPhone}.`)
+        }
+      })
+    }
     return `${area}-${prefix}-${line}`
   })
   .set(function (v) {
     // regular expression that accepts multiple valid U. S. phone number formats
     // see http://regexlib.com/REDetails.aspx?regexp_id=58
     // modified to ignore trailing/leading whitespace and disallow alphanumeric characters
-    var re = /^\s*(?:[0-9](?: |-)?)?(?:\(?([0-9]{3})\)?|[0-9]{3})(?: |-)?(?:([0-9]{3})(?: |-)?([0-9]{4}))\s*$/
-    var [, area, prefix, line] = v.match(re) || []
+    var [, area, prefix, line] = v.match(PHONE_REGEX) || []
     this.phone = `${area}${prefix}${line}`
   })
 

--- a/models/User.js
+++ b/models/User.js
@@ -496,7 +496,7 @@ userSchema.virtual('phonePretty')
       return null
     }
 
-    // first test user's phone number to see if it's a valid U.S. phone numer
+    // first test user's phone number to see if it's a valid U.S. phone number
     var matches = this.phone.match(PHONE_REGEX)
     if (!matches) {
       return null

--- a/models/User.js
+++ b/models/User.js
@@ -506,11 +506,11 @@ userSchema.virtual('phonePretty')
       // autocorrect phone number format
       var oldPhone = this.phone
       this.phone = `${area}${prefix}${line}`
-      this.save(function (err, newPhone) {
+      this.save(function (err, user) {
         if (err) {
           console.log(err)
         } else {
-          console.log(`Phone number ${oldPhone} corrected to ${newPhone}.`)
+          console.log(`Phone number ${oldPhone} corrected to ${user}.`)
         }
       })
     }

--- a/models/User.js
+++ b/models/User.js
@@ -484,6 +484,9 @@ userSchema.methods.verifyPassword = function (candidatePassword, cb) {
   })
 }
 
+// regular expression that accepts multiple valid U. S. phone number formats
+// see http://regexlib.com/REDetails.aspx?regexp_id=58
+// modified to ignore trailing/leading whitespace and disallow alphanumeric characters
 const PHONE_REGEX = /^\s*(?:[0-9](?: |-)?)?(?:\(?([0-9]{3})\)?|[0-9]{3})(?: |-)?(?:([0-9]{3})(?: |-)?([0-9]{4}))\s*$/
 
 // virtual type for phone number formatted for readability
@@ -499,6 +502,8 @@ userSchema.virtual('phonePretty')
       return null
     }
 
+    // ignore first element of matches, which is the full regex match,
+    // and destructure remaining portion
     var [, area, prefix, line] = matches
     // accepted phone number format in database
     var reStrict = /^([0-9]{3})([0-9]{3})([0-9]{4})$/
@@ -517,9 +522,8 @@ userSchema.virtual('phonePretty')
     return `${area}-${prefix}-${line}`
   })
   .set(function (v) {
-    // regular expression that accepts multiple valid U. S. phone number formats
-    // see http://regexlib.com/REDetails.aspx?regexp_id=58
-    // modified to ignore trailing/leading whitespace and disallow alphanumeric characters
+    // ignore first element of match result, which is the full match,
+    // and destructure the remaining portion
     var [, area, prefix, line] = v.match(PHONE_REGEX) || []
     this.phone = `${area}${prefix}${line}`
   })

--- a/models/User.js
+++ b/models/User.js
@@ -510,7 +510,7 @@ userSchema.virtual('phonePretty')
         if (err) {
           console.log(err)
         } else {
-          console.log(`Phone number ${oldPhone} corrected to ${user}.`)
+          console.log(`Phone number ${oldPhone} corrected to ${user.phone}.`)
         }
       })
     }

--- a/models/User.js
+++ b/models/User.js
@@ -522,10 +522,14 @@ userSchema.virtual('phonePretty')
     return `${area}-${prefix}-${line}`
   })
   .set(function (v) {
-    // ignore first element of match result, which is the full match,
-    // and destructure the remaining portion
-    var [, area, prefix, line] = v.match(PHONE_REGEX) || []
-    this.phone = `${area}${prefix}${line}`
+    if (!v) {
+      this.phone = v
+    } else {
+      // ignore first element of match result, which is the full match,
+      // and destructure the remaining portion
+      var [, area, prefix, line] = v.match(PHONE_REGEX) || []
+	  this.phone = `${area}${prefix}${line}`
+    }
   })
 
 // Static method to determine if a registration code is valid


### PR DESCRIPTION
Links
-----
Task: https://www.notion.so/upchieve/Fix-server-side-phone-number-getter-for-numbers-stored-the-wrong-way-in-the-database-f842a3c890b14750925a459b7ced95f8

Related PRs: https://github.com/UPchieve/server/pull/99 (original phone number formatting), https://github.com/UPchieve/server/pull/100 (utility script to autocorrect those numbers that can be)

Description
-----------
The formatting code in the current master branch works well to ensure that phone numbers of new users are stored correctly in the database for twilio.js, but users whose phone numbers are stored incorrectly in the database before deployment will not be able to log in once master is deployed. This PR allows users who have entered their phone numbers incorrectly to still log in by preventing the virtual getters for formatted phone numbers from throwing an error in the event that it doesn't match the regex, and by autocorrecting it to the right format for the database if it is still a valid U.S. phone number.

We may also want to prompt users when they login to update their phone numbers if theirs are not valid; the script will correct valid U.S. phone numbers that aren't formatted the way Twilio wants them, but it won't correct entries that are not valid U.S. phone numbers.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] PR link has been posted in the task's comments
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] Task and PR have been updated to show that this is ready for review
