### PR TITLE
Fix availability time calculations for Twilio notifications

### DIFF
--- a/services/twilio.js
+++ b/services/twilio.js
@@ -21,11 +21,21 @@ function getAvailability () {
   var min = date.minute() / 60
 
   if (min >= 0.5) {
-    hour++
+    hour = (hour + 1) % 24
+    if (hour === 0) {
+      // check availability at midnight on the next day
+      day = (day + 1) % 7
+    }
   }
-  if (hour > 12) {
-    hour = `${hour - 12}p`
+  if (hour >= 12) {
+    if (hour > 12) {
+      hour -= 12
+    }
+    hour = `${hour}p`
   } else {
+    if (hour === 0) {
+      hour = 12
+    }
     hour = `${hour}a`
   }
 


### PR DESCRIPTION
Description
-----------
The function in `twilio.js` that computes the name of the correct `availability` field to use to determine which volunteers to notify does not produce correct results for some cases. Specifically, it does not work properly when the current time is:

- less than a half hour before midnight (it returns `availability.Tuesday.12p` at 11:57 pm Eastern Time on Tuesday)
- less than a half hour after midnight (it returns `availability.Tuesday.0a` at 12:17 am Eastern Time on Tuesday)
- within a half hour of noon (it returns `availability.Tuesday.12a` at 12:18 pm Eastern Time on Tuesday)

This PR fixes the availability logic to correct this behavior.

Developer self-review checklist
-------------------------------
- [ ] Task's requirements have been fully addressed
- [ ] Potentially confusing code has been explained with comments
- [ ] Posted a link to this PR on the Notion task
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [ ] All new code complies with our ESLint standards
