### PR TITLE
Always initialize availability fields for users that have not yet entered schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ UPchieve web server
     - [POST /api/session/check](#post-apisessioncheck)
     - [POST /api/training/questions](#post-apitrainingquestions)
     - [POST /api/training/score](#post-apitrainingscore)
-    - [POST /api/calendar/init](#post-apicalendarinit)
     - [POST /api/calendar/get](#post-apicalendarget)
     - [POST /api/calendar/save](#post-apicalendarsave)
     - [POST /api/feedback](#post-apifeedback)
@@ -251,14 +250,6 @@ Possible errors:
   "userid": "String",
   "idAnswerMap": "String",
   "category": "String"
-}
-```
-
-### POST /api/calendar/init
-
-```json
-{
-  "userid": "String"
 }
 ```
 

--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -238,6 +238,7 @@ module.exports = {
         return callback(new Error('No account with that id found.'))
       }
       user.availability = availability
+      user.hasSchedule = true
       user.save(function (err, user) {
         if (err) {
           callback(err, null)

--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -1,245 +1,230 @@
 var User = require('../models/User')
 
-module.exports = {
-  initAvailability: function (options, callback) {
-    var userid = options.userid
-    var availability = {
-      Sunday: {
-        '12a': false,
-        '1a': false,
-        '2a': false,
-        '3a': false,
-        '4a': false,
-        '5a': false,
-        '6a': false,
-        '7a': false,
-        '8a': false,
-        '9a': false,
-        '10a': false,
-        '11a': false,
-        '12p': false,
-        '1p': false,
-        '2p': false,
-        '3p': false,
-        '4p': false,
-        '5p': false,
-        '6p': false,
-        '7p': false,
-        '8p': false,
-        '9p': false,
-        '10p': false,
-        '11p': false
-      },
-      Monday: {
-        '12a': false,
-        '1a': false,
-        '2a': false,
-        '3a': false,
-        '4a': false,
-        '5a': false,
-        '6a': false,
-        '7a': false,
-        '8a': false,
-        '9a': false,
-        '10a': false,
-        '11a': false,
-        '12p': false,
-        '1p': false,
-        '2p': false,
-        '3p': false,
-        '4p': false,
-        '5p': false,
-        '6p': false,
-        '7p': false,
-        '8p': false,
-        '9p': false,
-        '10p': false,
-        '11p': false
-      },
-      Tuesday: {
-        '12a': false,
-        '1a': false,
-        '2a': false,
-        '3a': false,
-        '4a': false,
-        '5a': false,
-        '6a': false,
-        '7a': false,
-        '8a': false,
-        '9a': false,
-        '10a': false,
-        '11a': false,
-        '12p': false,
-        '1p': false,
-        '2p': false,
-        '3p': false,
-        '4p': false,
-        '5p': false,
-        '6p': false,
-        '7p': false,
-        '8p': false,
-        '9p': false,
-        '10p': false,
-        '11p': false
-      },
-      Wednesday: {
-        '12a': false,
-        '1a': false,
-        '2a': false,
-        '3a': false,
-        '4a': false,
-        '5a': false,
-        '6a': false,
-        '7a': false,
-        '8a': false,
-        '9a': false,
-        '10a': false,
-        '11a': false,
-        '12p': false,
-        '1p': false,
-        '2p': false,
-        '3p': false,
-        '4p': false,
-        '5p': false,
-        '6p': false,
-        '7p': false,
-        '8p': false,
-        '9p': false,
-        '10p': false,
-        '11p': false
-      },
-      Thursday: {
-        '12a': false,
-        '1a': false,
-        '2a': false,
-        '3a': false,
-        '4a': false,
-        '5a': false,
-        '6a': false,
-        '7a': false,
-        '8a': false,
-        '9a': false,
-        '10a': false,
-        '11a': false,
-        '12p': false,
-        '1p': false,
-        '2p': false,
-        '3p': false,
-        '4p': false,
-        '5p': false,
-        '6p': false,
-        '7p': false,
-        '8p': false,
-        '9p': false,
-        '10p': false,
-        '11p': false
-      },
-      Friday: {
-        '12a': false,
-        '1a': false,
-        '2a': false,
-        '3a': false,
-        '4a': false,
-        '5a': false,
-        '6a': false,
-        '7a': false,
-        '8a': false,
-        '9a': false,
-        '10a': false,
-        '11a': false,
-        '12p': false,
-        '1p': false,
-        '2p': false,
-        '3p': false,
-        '4p': false,
-        '5p': false,
-        '6p': false,
-        '7p': false,
-        '8p': false,
-        '9p': false,
-        '10p': false,
-        '11p': false
-      },
-      Saturday: {
-        '12a': false,
-        '1a': false,
-        '2a': false,
-        '3a': false,
-        '4a': false,
-        '5a': false,
-        '6a': false,
-        '7a': false,
-        '8a': false,
-        '9a': false,
-        '10a': false,
-        '11a': false,
-        '12p': false,
-        '1p': false,
-        '2p': false,
-        '3p': false,
-        '4p': false,
-        '5p': false,
-        '6p': false,
-        '7p': false,
-        '8p': false,
-        '9p': false,
-        '10p': false,
-        '11p': false
-      }
+function initAvailability (user, callback) {
+  var availability = {
+    Sunday: {
+      '12a': false,
+      '1a': false,
+      '2a': false,
+      '3a': false,
+      '4a': false,
+      '5a': false,
+      '6a': false,
+      '7a': false,
+      '8a': false,
+      '9a': false,
+      '10a': false,
+      '11a': false,
+      '12p': false,
+      '1p': false,
+      '2p': false,
+      '3p': false,
+      '4p': false,
+      '5p': false,
+      '6p': false,
+      '7p': false,
+      '8p': false,
+      '9p': false,
+      '10p': false,
+      '11p': false
+    },
+    Monday: {
+      '12a': false,
+      '1a': false,
+      '2a': false,
+      '3a': false,
+      '4a': false,
+      '5a': false,
+      '6a': false,
+      '7a': false,
+      '8a': false,
+      '9a': false,
+      '10a': false,
+      '11a': false,
+      '12p': false,
+      '1p': false,
+      '2p': false,
+      '3p': false,
+      '4p': false,
+      '5p': false,
+      '6p': false,
+      '7p': false,
+      '8p': false,
+      '9p': false,
+      '10p': false,
+      '11p': false
+    },
+    Tuesday: {
+      '12a': false,
+      '1a': false,
+      '2a': false,
+      '3a': false,
+      '4a': false,
+      '5a': false,
+      '6a': false,
+      '7a': false,
+      '8a': false,
+      '9a': false,
+      '10a': false,
+      '11a': false,
+      '12p': false,
+      '1p': false,
+      '2p': false,
+      '3p': false,
+      '4p': false,
+      '5p': false,
+      '6p': false,
+      '7p': false,
+      '8p': false,
+      '9p': false,
+      '10p': false,
+      '11p': false
+    },
+    Wednesday: {
+      '12a': false,
+      '1a': false,
+      '2a': false,
+      '3a': false,
+      '4a': false,
+      '5a': false,
+      '6a': false,
+      '7a': false,
+      '8a': false,
+      '9a': false,
+      '10a': false,
+      '11a': false,
+      '12p': false,
+      '1p': false,
+      '2p': false,
+      '3p': false,
+      '4p': false,
+      '5p': false,
+      '6p': false,
+      '7p': false,
+      '8p': false,
+      '9p': false,
+      '10p': false,
+      '11p': false
+    },
+    Thursday: {
+      '12a': false,
+      '1a': false,
+      '2a': false,
+      '3a': false,
+      '4a': false,
+      '5a': false,
+      '6a': false,
+      '7a': false,
+      '8a': false,
+      '9a': false,
+      '10a': false,
+      '11a': false,
+      '12p': false,
+      '1p': false,
+      '2p': false,
+      '3p': false,
+      '4p': false,
+      '5p': false,
+      '6p': false,
+      '7p': false,
+      '8p': false,
+      '9p': false,
+      '10p': false,
+      '11p': false
+    },
+    Friday: {
+      '12a': false,
+      '1a': false,
+      '2a': false,
+      '3a': false,
+      '4a': false,
+      '5a': false,
+      '6a': false,
+      '7a': false,
+      '8a': false,
+      '9a': false,
+      '10a': false,
+      '11a': false,
+      '12p': false,
+      '1p': false,
+      '2p': false,
+      '3p': false,
+      '4p': false,
+      '5p': false,
+      '6p': false,
+      '7p': false,
+      '8p': false,
+      '9p': false,
+      '10p': false,
+      '11p': false
+    },
+    Saturday: {
+      '12a': false,
+      '1a': false,
+      '2a': false,
+      '3a': false,
+      '4a': false,
+      '5a': false,
+      '6a': false,
+      '7a': false,
+      '8a': false,
+      '9a': false,
+      '10a': false,
+      '11a': false,
+      '12p': false,
+      '1p': false,
+      '2p': false,
+      '3p': false,
+      '4p': false,
+      '5p': false,
+      '6p': false,
+      '7p': false,
+      '8p': false,
+      '9p': false,
+      '10p': false,
+      '11p': false
     }
+  }
 
-    User.findOne({ _id: userid }, function (err, user) {
-      if (err) {
-        return callback(err)
-      }
-      if (!user) {
-        return callback(new Error('No account with that id found.'))
-      }
-      user.availability = availability
-      user.hasSchedule = true
-      user.timezone = ''
-      user.save(function (err, user) {
-        if (err) {
-          callback(err, null)
-        } else {
-          callback(null, availability)
-        }
-      })
+  user.availability = availability
+  user.hasSchedule = true
+  user.timezone = ''
+
+  const promise = user.save()
+    .then(user => {
+      return availability
     })
-  },
 
+  if (!callback) {
+    return promise
+  } else {
+    promise
+      .then(availability => callback(null, availability))
+      .catch(err => callback(err))
+  }
+}
+
+module.exports = {
   getAvailability: function (options, callback) {
     var userid = options.userid
 
-    User.findOne({ _id: userid }, (err, user) => {
-      if (err) {
-        return callback(err)
-      }
-      if (!user) {
-        return callback(new Error('No account with that id found.'))
-      }
-
-      // promise to automatically init availability only if necessary
-      const initAvailabilityPromise = new Promise((resolve, reject) => {
-        if (user.hasSchedule) {
-          resolve(user.availability)
-        } else {
-          this.initAvailability({ userid }, (err, availability) => {
-            if (err) {
-              reject(err)
-            } else {
-              resolve(availability)
-            }
-          })
+    User.findOne({ _id: userid }).exec()
+      .then(user => {
+        if (!user) {
+          throw new Error('No account with that id found.')
         }
-      })
 
-      initAvailabilityPromise.then((availability) => {
+        if (user.hasSchedule) {
+          return user.availability
+        } else {
+          return initAvailability(user)
+        }
+      }).then(availability => {
         callback(null, availability)
-      }).catch((err) => {
+      }).catch(err => {
+        console.log(err)
         callback(err)
       })
-    })
   },
 
   updateAvailability: function (options, callback) {

--- a/router/api/calendar.js
+++ b/router/api/calendar.js
@@ -1,17 +1,6 @@
 var CalendarCtrl = require('../../controllers/CalendarCtrl')
 
 module.exports = function (router) {
-  router.post('/calendar/init', function (req, res) {
-    CalendarCtrl.initAvailability({ userid: req.body.userid }, function (err) {
-      if (err) {
-        res.json({ err: err })
-      } else {
-        res.json({
-          msg: 'Availability initialized'
-        })
-      }
-    })
-  })
   router.post('/calendar/get', function (req, res) {
     CalendarCtrl.getAvailability({ userid: req.body.userid }, function (
       err,


### PR DESCRIPTION
Links
-----
- Web repo PR: https://github.com/UPchieve/web/pull/210

Description
-----------
The current calendar API is designed to work when the user's `availability` fields have all been preset to `false`, and relies on the client to know when it needs to initialize them by tracking the `hasSchedule` boolean field and calling the `/api/calendar/init` endpoint. This PR eliminates this dependence upon the client to properly initialize the fields by automatically initializing them in the controller on the server whenever the client accesses them through the `getAvailability` function. This also eliminates an issue that caused the calendar to sometimes fail to display the selectable boxes for the user's availability schedule when the user's availability was not yet initialized; the client would call the `/api/calendar/init` endpoint, initializing the availability on the server, but did not set the availability object in the browser after it was initialized. With this PR, the issue disappears because the client is displaying the availability obtained from `/api/calendar/get`, which now calls `initAvailability` automatically.

Because of the issue mentioned above, when testing on my local machine I would sometimes set the availability fields in the database directly using the Mongo shell, resulting in only some of the fields in the availability object being defined. This partially defined availability object seems to cause problems with conversion between the time zone of the user to the default time zone of the availability fields on the server (America/New_York). I don't know if UPchieve admins have done the same thing for users who could not set the availability via the web app, but if so then we will need a separate PR to ensure that the availability fields for these users are stored correctly in the database.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [ ] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
