### PR TITLE
Added auto formatting for school names, and option to disable.

### DIFF
--- a/dbutils/import-nces-highschools.js
+++ b/dbutils/import-nces-highschools.js
@@ -140,16 +140,16 @@ dbconnect(mongoose, function () {
         console.error('This script needs a valid URL to import data.')
         return done(new Error('missing URL argument'))
       }
-      
+
       const options = {}
-      
+
       try {
         optionArgs.forEach(arg => {
           if (arg.charAt(0) !== '-') {
             console.error('Optional arguments must be preceded by a hyphen (\'-\').')
             throw new Error(`invalid option: ${arg}`)
           }
-          
+
           const key = arg.slice(1)
           if ([
             'dontconvertname'
@@ -335,7 +335,7 @@ dbconnect(mongoose, function () {
       progressBar.start(schools.length, 0)
 
       const convertName = !options.dontconvertname
-      
+
       async.mapSeries(schools, function (school, callback) {
         School.find({
           ST_SCHID: school.ST_SCHID
@@ -363,7 +363,7 @@ dbconnect(mongoose, function () {
             })
           } else {
             addNewSchool(school, convertName, (err) => {
-              progressBar.increment(),
+              progressBar.increment()
               callback(err)
             })
           }

--- a/dbutils/import-nces-highschools.js
+++ b/dbutils/import-nces-highschools.js
@@ -17,7 +17,14 @@ const dbconnect = require('./dbconnect')
 
 const School = require('../models/School')
 
-function addNewSchool (school, done) {
+// helper to convert names to title case
+function toTitleCase (str) {
+  return str.split(' ')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ')
+}
+
+function addNewSchool (school, convertName, done) {
   // create unique upchieveId
   const hash = crypto.createHash('sha1')
   hash.update(school.ST_SCHID)
@@ -32,6 +39,9 @@ function addNewSchool (school, done) {
 
     // populate fields
     Object.keys(school).forEach((key) => {
+      if (convertName && (key === 'SCH_NAME' || key === 'LCITY') ) {
+        newSchool[key] = toTitleCase(school[key])
+      }
       newSchool[key] = school[key]
     })
 
@@ -122,11 +132,35 @@ dbconnect(mongoose, function () {
     },
     // retrieve the data
     function (done) {
-      // get the NCES URL from the first user argument
-      const url = process.argv[2]
+      // get the NCES URL from the first user argument after any options
+      const optionArgs = process.argv.slice(2, -1)
+      const url = process.argv[process.argv.length - 1]
       if (!url) {
         console.error('This script needs a valid URL to import data.')
         return done(new Error('missing URL argument'))
+      }
+      
+      const options = {}
+      
+      try {
+        optionArgs.forEach(arg => {
+          if (arg.charAt(0) !== '-') {
+            console.error('Optional arguments must be preceded by a hyphen (\'-\').')
+            throw new Error(`invalid option: ${arg}`)
+          }
+          
+          const key = arg.slice(1)
+          if ([
+            'dontconvertname'
+          ].includes(key)) {
+            options[key] = true
+          } else {
+            console.error(`Option ${arg} is not recognized.`)
+            throw new Error(`unrecognized option: ${arg}`)
+          }
+        })
+      } catch (err) {
+        return done(err)
       }
 
       https.get(url, res => {
@@ -157,7 +191,7 @@ dbconnect(mongoose, function () {
           res.on('end', () => {
             const buf = Buffer.concat(data)
 
-            return done(null, 'zip', buf, dataLength)
+            return done(null, 'zip', buf, dataLength, options)
           })
         } else if (isCsv) {
           res.setEncoding('utf8')
@@ -167,7 +201,7 @@ dbconnect(mongoose, function () {
           res.on('data', (chunk) => { data += chunk })
 
           res.on('end', () => {
-            return done(null, 'csv', data, data.length)
+            return done(null, 'csv', data, data.length, options)
           })
         }
       }).on('error', (err) => {
@@ -175,14 +209,14 @@ dbconnect(mongoose, function () {
       })
     },
     // unzip the file
-    function (format, data, dataLength, done) {
+    function (format, data, dataLength, options, done) {
       if (!['csv', 'zip'].includes(format)) {
         return done(new Error(`unsupported file format: ${format}`))
       }
 
       if (format === 'csv') {
         // skip to CSV parser
-        return done(null, data, dataLength)
+        return done(null, data, dataLength, options)
       } else if (format === 'zip') {
         console.log('Extracting zip file')
         JSZip.loadAsync(data)
@@ -192,7 +226,7 @@ dbconnect(mongoose, function () {
               if (!foundCsv && relPath.endsWith('.csv')) {
                 foundCsv = true
                 file.async('string').then((csvString) => {
-                  return done(null, csvString, csvString.length)
+                  return done(null, csvString, csvString.length, options)
                 }).catch(done)
               }
             })
@@ -204,7 +238,7 @@ dbconnect(mongoose, function () {
       }
     },
     // parse the CSV
-    function (data, dataLength, done) {
+    function (data, dataLength, options, done) {
       console.log('Parsing CSV')
       const parser = csvParse({
         cast: function (value, context) {
@@ -238,14 +272,14 @@ dbconnect(mongoose, function () {
       parser.on('error', done)
 
       parser.on('end', () => {
-        done(null, schools)
+        done(null, schools, options)
       })
 
       parser.write(data)
       parser.end()
     },
     // clear old NCES data entries
-    function (schools, done) {
+    function (schools, options, done) {
       console.log('Clearing old schools')
       School.find({
         ST_SCHID: { $exists: true }
@@ -286,18 +320,20 @@ dbconnect(mongoose, function () {
           if (err) {
             done(err)
           } else {
-            done(null, schools)
+            done(null, schools, options)
           }
         })
       })
     },
     // add schools to database
-    function (schools, done) {
+    function (schools, options, done) {
       console.log('Updating records...')
       const progressBar = new cliProgress.SingleBar({}, cliProgress.Presets.shades_classic)
 
       progressBar.start(schools.length, 0)
 
+      const convertName = !options.dontconvertname
+      
       async.mapSeries(schools, function (school, callback) {
         School.find({
           ST_SCHID: school.ST_SCHID
@@ -311,7 +347,12 @@ dbconnect(mongoose, function () {
             const data = results[0]
 
             Object.keys(school).forEach((key) => {
-              data[key] = school[key]
+              if (convertName && (key === 'SCH_NAME' || key === 'LCITY')) {
+                // convert automatically imported names and cities
+                data[key] = toTitleCase(school[key])
+              } else {
+                data[key] = school[key]
+              }
             })
 
             data.save((err) => {
@@ -320,7 +361,8 @@ dbconnect(mongoose, function () {
             })
           } else {
             addNewSchool(school, (err) => {
-              progressBar.increment()
+              progressBar.increment(),
+              convertName,
               callback(err)
             })
           }

--- a/dbutils/import-nces-highschools.js
+++ b/dbutils/import-nces-highschools.js
@@ -18,7 +18,14 @@ const dbconnect = require('./dbconnect')
 const School = require('../models/School')
 
 // helper to convert names to title case
-function toTitleCase (str) {
+function toTitleCaseIfAllCaps (str) {
+  const isAllCaps = typeof str === 'string' &&
+    str === str.toUpperCase()
+
+  if (!isAllCaps) {
+    return str
+  }
+
   return str.split(' ')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ')
@@ -39,8 +46,8 @@ function addNewSchool (school, convertName, done) {
 
     // populate fields
     Object.keys(school).forEach((key) => {
-      if (convertName && (key === 'SCH_NAME' || key === 'LCITY') ) {
-        newSchool[key] = toTitleCase(school[key])
+      if (convertName && (key === 'SCH_NAME' || key === 'LCITY')) {
+        newSchool[key] = toTitleCaseIfAllCaps(school[key])
       } else {
         newSchool[key] = school[key]
       }
@@ -351,7 +358,7 @@ dbconnect(mongoose, function () {
             Object.keys(school).forEach((key) => {
               if (convertName && (key === 'SCH_NAME' || key === 'LCITY')) {
                 // convert automatically imported names and cities
-                data[key] = toTitleCase(school[key])
+                data[key] = toTitleCaseIfAllCaps(school[key])
               } else {
                 data[key] = school[key]
               }

--- a/dbutils/import-nces-highschools.js
+++ b/dbutils/import-nces-highschools.js
@@ -41,8 +41,9 @@ function addNewSchool (school, convertName, done) {
     Object.keys(school).forEach((key) => {
       if (convertName && (key === 'SCH_NAME' || key === 'LCITY') ) {
         newSchool[key] = toTitleCase(school[key])
+      } else {
+        newSchool[key] = school[key]
       }
-      newSchool[key] = school[key]
     })
 
     newSchool.save((err) => {
@@ -160,6 +161,7 @@ dbconnect(mongoose, function () {
           }
         })
       } catch (err) {
+        // errors thrown in forEach loop are caught here and passed to done
         return done(err)
       }
 
@@ -360,9 +362,8 @@ dbconnect(mongoose, function () {
               callback(err)
             })
           } else {
-            addNewSchool(school, (err) => {
+            addNewSchool(school, convertName, (err) => {
               progressBar.increment(),
-              convertName,
               callback(err)
             })
           }


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Auto-format-school-and-city-names-when-importing-them-128b10c4f31341f19ec622e5d4a6eeb7

Description
-----------
This PR changes the `import-nces-highschools.js` script to automatically format all school names and city names in title case (first letter of each word is capital, second letter is lowercase), unless an option `-dontconvertnames` is specified before the URL.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
