### PR TITLE
Fix: Notification references in Session object

### DIFF
--- a/models/Session.js
+++ b/models/Session.js
@@ -137,9 +137,12 @@ sessionSchema.methods.endSession = function (cb) {
   this.save(() => console.log(`Ended session ${this._id} at ${this.endedAt}`))
 }
 
-sessionSchema.methods.addNotification = function (notification, cb) {
-  this.notifications.push(notification)
-  return this.save(cb)
+sessionSchema.methods.addNotifications = function (notificationsToAdd, cb) {
+  return this.model('Session')
+    .findByIdAndUpdate(this._id, {
+      $push: { notifications: { $each: notificationsToAdd } }
+    })
+    .exec(cb)
 }
 
 sessionSchema.methods.isActive = function (cb) {}

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -233,11 +233,11 @@ module.exports = {
           // early exit
           return
         }
-        
+
         console.log(persons.map(person => person._id))
         // notifications to record in the Session instance
         const notifications = []
-        
+
         async.each(persons, (person, cb) => {
           // record notification in database
           const notification = new Notification({
@@ -256,10 +256,10 @@ module.exports = {
           if (err) {
             console.log(err)
           }
-          
+
           // save notifications to Session instance
           session.addNotifications(notifications)
-          
+
           // failsafe notifications
           this.notifyFailsafe(student, type, subtopic, options)
         })
@@ -273,7 +273,7 @@ module.exports = {
       .then(function (persons) {
         // notifications to record in the Session instance
         const notifications = []
-        
+
         async.each(persons, (person, cb) => {
           var isFirstTimeRequester = !student.pastSessions || !student.pastSessions.length
 
@@ -312,7 +312,7 @@ module.exports = {
           if (err) {
             console.log(err)
           }
-          
+
           // add the notifications to the Session object
           session.addNotifications(notifications)
         })

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -2,6 +2,7 @@ var config = require('../config.js')
 var User = require('../models/User')
 var twilio = require('twilio')
 var moment = require('moment-timezone')
+const async = require('async')
 const client = twilio(config.accountSid, config.authToken)
 
 const Notification = require('../models/Notification')
@@ -196,11 +197,10 @@ function sendFailsafe (phoneNumber, name, options) {
  * @param {sendPromise} a Promise that resolves to the message SID
  * @param {notification} the notification object to save
  * after the message is sent to Twilio
- * @param {session} the session that triggered the notification
  * @returns a Promise that resolves to the saved notification
  * object
  */
-function recordNotification (sendPromise, notification, session) {
+function recordNotification (sendPromise, notification) {
   return sendPromise.then(sid => {
     // record notification in database
     notification.wasSuccessful = true
@@ -213,8 +213,6 @@ function recordNotification (sendPromise, notification, session) {
     return notification
   }).then(notification => {
     return notification.save()
-  }).then(notification => {
-    return session.addNotification(notification)
   })
 }
 
@@ -229,25 +227,43 @@ module.exports = {
       isTestUserRequest,
       shouldGetFailsafe: false
     })
-      .exec(function (err, persons) {
+      .exec((err, persons) => {
         if (err) {
           console.log(err)
           // early exit
           return
         }
-        persons.forEach(person => {
+        
+        console.log(persons.map(person => person._id))
+        // notifications to record in the Session instance
+        const notifications = []
+        
+        async.each(persons, (person, cb) => {
           // record notification in database
           const notification = new Notification({
             volunteer: person,
             method: 'SMS'
           })
           const sendPromise = send(person.phone, person.firstname, subtopic, isTestUserRequest)
-          recordNotification(sendPromise, notification, session).catch(err => console.log(err))
+          // wait for recordNotification to succeed or fail before callback,
+          // and don't break loop if only one message fails
+          recordNotification(sendPromise, notification)
+            .then(notification => notifications.push(notification))
+            .catch(err => console.log(err))
+            .finally(cb)
+        },
+        (err) => {
+          if (err) {
+            console.log(err)
+          }
+          
+          // save notifications to Session instance
+          session.addNotifications(notifications)
+          
+          // failsafe notifications
+          this.notifyFailsafe(student, type, subtopic, options)
         })
       })
-
-    // failsafe notifications
-    this.notifyFailsafe(student, type, subtopic, options)
   },
   // notify failsafe volunteers
   notifyFailsafe: function (student, type, subtopic, options) {
@@ -255,7 +271,10 @@ module.exports = {
 
     getFailsafeVolunteersFromDb().exec()
       .then(function (persons) {
-        persons.forEach(function (person) {
+        // notifications to record in the Session instance
+        const notifications = []
+        
+        async.each(persons, (person, cb) => {
           var isFirstTimeRequester = !student.pastSessions || !student.pastSessions.length
 
           const notification = new Notification({
@@ -283,7 +302,19 @@ module.exports = {
               voice: options && options.voice,
               isTestUserRequest: options && options.isTestUserRequest
             })
-          recordNotification(sendPromise, notification, session).catch(err => console.log(err))
+          // wait for recordNotification to succeed or fail before callback,
+          // and don't break loop if only one message fails
+          recordNotification(sendPromise, notification, session)
+            .then(notification => notifications.push(notification))
+            .catch(err => console.log(err))
+            .finally(cb)
+        }, (err) => {
+          if (err) {
+            console.log(err)
+          }
+          
+          // add the notifications to the Session object
+          session.addNotifications(notifications)
         })
       })
   }


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Stored-notifications-follow-up-7c957b5cf6384f06bc80ed20be623db1

Description
-----------
The logic for saving references to the `Notification` objects in the `Session` model involved loading the array into memory, pushing the new object into the array, and saving it to the database. This resulted in race conditions when multiple notifications were sent concurrently, because the function `Session.addNotification` was operating on an in-memory array that was not necessarily up-to-date with the array in the database. This PR does two things to address this problem:

1. Changes `Session.addNotification` to work directly with the MongoDB database to add the reference, rather than working with an in-memory JavaScript array.
2. Changes `twilio.notify` to add the notifications in one database operation after they have all been sent, rather than each one separately after it is sent.

Developer self-review checklist
-------------------------------
- [ ] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [ ] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
