### PR TITLE
Fixed obsolete 'highschool' references

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -293,25 +293,24 @@ module.exports = {
       twilioService.notify(user, type, subTopic, {
         isTestUserRequest: user.isTestUser,
         session: savedSession
+      }, (session) => {
+        // second SMS failsafe notifications
+        newSessionTimekeeper.setSessionTimeout(session, config.desperateSMSTimeout,
+          twilioService.notifyFailsafe, user, type, subTopic, {
+            desperate: true,
+            isTestUserRequest: user.isTestUser,
+            session
+          })
+
+        // failsafe voice notification
+        newSessionTimekeeper.setSessionTimeout(session, config.desperateVoiceTimeout,
+          twilioService.notifyFailsafe, user, type, subTopic, {
+            desperate: true,
+            voice: true,
+            isTestUserRequest: user.isTestUser,
+            session
+          })
       })
-
-      // second SMS failsafe notifications
-      newSessionTimekeeper.setSessionTimeout(session, config.desperateSMSTimeout,
-        twilioService.notifyFailsafe, user, type, subTopic, {
-          desperate: true,
-          isTestUserRequest: user.isTestUser,
-          session: savedSession
-        })
-
-      // failsafe voice notification
-      newSessionTimekeeper.setSessionTimeout(session, config.desperateVoiceTimeout,
-        twilioService.notifyFailsafe, user, type, subTopic,
-        {
-          desperate: true,
-          voice: true,
-          isTestUserRequest: user.isTestUser,
-          session: savedSession
-        })
 
       cb(null, savedSession)
     })

--- a/models/User.js
+++ b/models/User.js
@@ -512,6 +512,12 @@ userSchema.methods.verifyPassword = function (candidatePassword, cb) {
   })
 }
 
+// Populates user document with the fields from the School document
+// necessary to retrieve the high school name
+userSchema.methods.populateForHighschoolName = function (cb) {
+  return this.populate('approvedHighschool', 'nameStored SCH_NAME', cb)
+}
+
 // regular expression that accepts multiple valid U. S. phone number formats
 // see http://regexlib.com/REDetails.aspx?regexp_id=58
 // modified to ignore trailing/leading whitespace and disallow alphanumeric characters

--- a/package-lock.json
+++ b/package-lock.json
@@ -3375,7 +3375,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3396,12 +3397,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3416,17 +3419,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3543,7 +3549,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3555,6 +3562,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3569,6 +3577,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3576,12 +3585,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3600,6 +3611,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3680,7 +3692,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3692,6 +3705,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3777,7 +3791,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3813,6 +3828,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3832,6 +3848,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3875,12 +3892,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/router/api/user.js
+++ b/router/api/user.js
@@ -32,7 +32,6 @@ module.exports = function (router) {
           preferredTimes: data.preferredTimes,
           phone: data.phone,
           phonePretty: data.phonePretty,
-          highschool: data.highschool,
           currentGrade: data.currentGrade,
           expectedGraduation: data.expectedGraduation,
           difficultAcademicSubject: data.difficultAcademicSubject,

--- a/seeds/test_users.json
+++ b/seeds/test_users.json
@@ -44,7 +44,6 @@
     "groupIdentification": [],
     "heardFrom": "Internet search",
     "highestLevelEducation": [],
-    "highschool": "High School",
     "isAdmin": false,
     "isTestUser": true,
     "isVolunteer": false,

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -219,7 +219,7 @@ function recordNotification (sendPromise, notification) {
 
 module.exports = {
   // notify both standard and failsafe volunteers
-  notify: function (student, type, subtopic, options) {
+  notify: function (student, type, subtopic, options, cb) {
     var isTestUserRequest = options.isTestUserRequest || false
     const session = options.session
 
@@ -245,6 +245,7 @@ module.exports = {
             volunteer: person,
             method: 'SMS'
           })
+
           const sendPromise = send(person.phone, person.firstname, subtopic, isTestUserRequest)
           // wait for recordNotification to succeed or fail before callback,
           // and don't break loop if only one message fails
@@ -267,6 +268,10 @@ module.exports = {
 
               // failsafe notifications
               this.notifyFailsafe(student, type, subtopic, options)
+
+              if (cb) {
+                cb(modifiedSession)
+              }
             })
             .catch(err => console.log(err))
         })
@@ -337,7 +342,7 @@ module.exports = {
           session.addNotifications(notifications)
         })
       })
-      .catch (err => {
+      .catch(err => {
         console.log(err)
       })
   }

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -253,8 +253,12 @@ module.exports = {
   notifyFailsafe: function (student, type, subtopic, options) {
     const session = options && options.session
 
-    getFailsafeVolunteersFromDb().exec()
-      .then(function (persons) {
+    Promise.all([
+      student.populateForHighschoolName().execPopulate(),
+      getFailsafeVolunteersFromDb().exec()
+    ])
+      .then(function (results) {
+        const [populatedStudent, persons] = results
         persons.forEach(function (person) {
           var isFirstTimeRequester = !student.pastSessions || !student.pastSessions.length
 
@@ -273,9 +277,9 @@ module.exports = {
             person.phone,
             person.firstname,
             {
-              studentFirstname: student.firstname,
-              studentLastname: student.lastname,
-              studentHighSchool: student.highschool,
+              studentFirstname: populatedStudent.firstname,
+              studentLastname: populatedStudent.lastname,
+              studentHighSchool: populatedStudent.highschoolName,
               isFirstTimeRequester,
               type,
               subtopic,

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -81,9 +81,11 @@ var getAvailableVolunteersFromDb = function (subtopic, options) {
     userQuery.isFailsafeVolunteer = false
   }
 
-  var query = User.find(userQuery)
-    .select({ phone: 1, firstname: 1 })
-    .limit(5)
+  const query = User.aggregate([
+    { $match: userQuery },
+    { $project: { phone: 1, firstname: 1 } },
+    { $sample: { size: 5 } }
+  ])
 
   return query
 }


### PR DESCRIPTION
Links
-----

Description
-----------
The `User` model was changed so that, instead of having an arbitrary string property `highschool`, it referenced a `School` object representing the user's high school. However, there were still several obsolete references to the old `highschool` property:

* The failsafe notification system was set to reference the old `highschool` property of the `User` model, but this property is obsolete, and referencing it always resulted in a value of `undefined` for the high school name since it was removed from the schema.
* The `/api/user` endpoint, as well as the `test_users.json` file used by `seed_test_users.sh`, still set the `highschool` property even though this field is no longer used.

This PR removes these obsolete references and replaces the old mechanism for sending the high school name to failsafe volunteers with a new one where we populate the `User` document's `approvedHighschool` field with the fields from `School` necessary to retrieve the high school name.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [ ] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
