### PR TITLE
Send failsafe volunteers the number of regular volunteers notified successfully

### DIFF
--- a/services/twilio.js
+++ b/services/twilio.js
@@ -343,5 +343,8 @@ module.exports = {
           session.addNotifications(notifications)
         })
       })
+      .catch (err => {
+        console.log(err)
+      })
   }
 }

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -172,12 +172,12 @@ function sendFailsafe (phoneNumber, name, options) {
   var isTestUserRequest = options.isTestUserRequest
 
   const firstTimeNotice = isFirstTimeRequester ? 'for the first time ' : ''
-    
+
   const numOfRegularVolunteersNotified = options.numOfRegularVolunteersNotified
 
   const numberOfVolunteersNotifiedMessage = `${numOfRegularVolunteersNotified} ` +
     `regular volunteer${numOfRegularVolunteersNotified === 1 ? ' has' : 's have'} been notified.`
-  
+
   let messageText
   if (desperate) {
     messageText = `Hi ${name}, student ${studentFirstname} ${studentLastname} ` +
@@ -286,17 +286,16 @@ module.exports = {
     session.populate('notifications')
       .execPopulate()
       .then((populatedSession) => {
-         return Promise.all([
-           populatedSession,
-           getFailsafeVolunteersFromDb().exec(),
-           populatedSession.notifications
-             .filter(notification => notification.type === 'REGULAR' && notification.wasSuccessful)
-             .length
-         ])
+        return Promise.all([
+          getFailsafeVolunteersFromDb().exec(),
+          populatedSession.notifications
+            .filter(notification => notification.type === 'REGULAR' && notification.wasSuccessful)
+            .length
+        ])
       })
       .then(function (results) {
-        const [populatedSession, persons, numOfRegularVolunteersNotified] = results
-        
+        const [persons, numOfRegularVolunteersNotified] = results
+
         // notifications to record in the Session instance
         const notifications = []
 


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Stored-notifications-follow-up-7c957b5cf6384f06bc80ed20be623db1

Description
-----------
Failsafe notifications will now receive the number of regular (non-failsafe) volunteers who have been _successfully_ notified when a session begins.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
