### PR TITLE
Populate virtuals for retrieving notifications sent to user, and session for notification

### DIFF
--- a/models/Notification.js
+++ b/models/Notification.js
@@ -29,6 +29,22 @@ const notificationSchema = new mongoose.Schema({
   },
   // Message ID returned by service, such as Twilio
   messageId: String
+},
+{
+  toJSON: {
+    virtuals: true
+  },
+
+  toObject: {
+    virtuals: true
+  }
+})
+
+notificationSchema.virtual('session', {
+  ref: 'Session',
+  localField: '_id',
+  foreignField: 'notifications',
+  justOne: true
 })
 
 module.exports = mongoose.model('Notification', notificationSchema)

--- a/models/User.js
+++ b/models/User.js
@@ -569,6 +569,14 @@ userSchema.virtual('highschoolName')
     }
   })
 
+// Virtual that gets all notifications that this user has been sent
+userSchema.virtual('notifications', {
+  ref: 'Notification',
+  localField: '_id',
+  foreignField: 'volunteer',
+  options: { sort: { sentAt: -1 } }
+})
+
 // Static method to determine if a registration code is valid
 userSchema.statics.checkCode = function (code, cb) {
   var volunteerCodes = config.VOLUNTEER_CODES.split(',')

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -343,5 +343,8 @@ module.exports = {
           session.addNotifications(notifications)
         })
       })
+      .catch (err => {
+        console.log(err)
+      })
   }
 }

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -172,12 +172,12 @@ function sendFailsafe (phoneNumber, name, options) {
   var isTestUserRequest = options.isTestUserRequest
 
   const firstTimeNotice = isFirstTimeRequester ? 'for the first time ' : ''
-    
+
   const numOfRegularVolunteersNotified = options.numOfRegularVolunteersNotified
 
   const numberOfVolunteersNotifiedMessage = `${numOfRegularVolunteersNotified} ` +
     `regular volunteer${numOfRegularVolunteersNotified === 1 ? ' has' : 's have'} been notified.`
-  
+
   let messageText
   if (desperate) {
     messageText = `Hi ${name}, student ${studentFirstname} ${studentLastname} ` +
@@ -286,17 +286,16 @@ module.exports = {
     session.populate('notifications')
       .execPopulate()
       .then((populatedSession) => {
-         return Promise.all([
-           populatedSession,
-           getFailsafeVolunteersFromDb().exec(),
-           populatedSession.notifications
-             .filter(notification => notification.type === 'REGULAR' && notification.wasSuccessful)
-             .length
-         ])
+        return Promise.all([
+          getFailsafeVolunteersFromDb().exec(),
+          populatedSession.notifications
+            .filter(notification => notification.type === 'REGULAR' && notification.wasSuccessful)
+            .length
+        ])
       })
       .then(function (results) {
-        const [populatedSession, persons, numOfRegularVolunteersNotified] = results
-        
+        const [persons, numOfRegularVolunteersNotified] = results
+
         // notifications to record in the Session instance
         const notifications = []
 


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Stored-notifications-follow-up-7c957b5cf6384f06bc80ed20be623db1

Description
-----------
A populate virtual, `notifications`, is added to the `User` schema to allow retrieving all of the notifications that have been sent to that user without storing an array of `ObjectId`s that will grow without bound. Another populate virtual, `session`, added to the `Notification` schema allows retrieval of the `Session` instance for which the notification was sent.

This branch is based on top of https://github.com/UPchieve/server/pull/133.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
