### PR TITLE
Ensure Vue-served quiz images appear in admin

### DIFF
--- a/router/edu/helpers.js
+++ b/router/edu/helpers.js
@@ -27,7 +27,18 @@ const isActivePage = req => {
   }
 }
 
+// Convert a given path of a front-end-served asset to the correct absolute or
+// relative path, based on the given frontEndRoot
+const frontEndPath = (relativePath, frontEndRoot) => {
+  if (frontEndRoot) {
+    return new URL(relativePath, frontEndRoot).toString()
+  } else {
+    return relativePath
+  }
+}
+
 module.exports = {
   questionsPath,
-  isActivePage
+  isActivePage,
+  frontEndPath
 }

--- a/router/edu/index.js
+++ b/router/edu/index.js
@@ -46,7 +46,7 @@ edu.route('/questions').get(async (req, res) => {
   try {
     const questions = await QuestionCtrl.list(req.query || {})
     const isActive = isActivePage(req)
-    
+
     // question._id --> URL
     const imagePaths = questions.reduce((map, question) => {
       map[question._id] = frontEndPath(question.imageSrc, edu.locals.frontEndRoot)

--- a/router/edu/index.js
+++ b/router/edu/index.js
@@ -4,7 +4,7 @@ const expressLayouts = require('express-ejs-layouts')
 const config = require('../../config')
 const passport = require('../auth/passport')
 const QuestionCtrl = require('../../controllers/QuestionCtrl')
-const { questionsPath, isActivePage } = require('./helpers')
+const { questionsPath, isActivePage, frontEndPath } = require('./helpers')
 
 console.log('Edu Admin module')
 
@@ -13,7 +13,8 @@ edu.set('view engine', 'ejs')
 edu.set('layout', 'layouts/edu')
 edu.use(expressLayouts)
 edu.locals = {
-  homeLink: config.NODE_ENV === 'dev' ? 'http://localhost:8080' : '/'
+  homeLink: config.NODE_ENV === 'dev' ? 'http://localhost:8080' : '/',
+  frontEndRoot: config.NODE_ENV === 'dev' ? new URL('http://localhost:8080') : null
 }
 
 // GET /edu
@@ -45,7 +46,14 @@ edu.route('/questions').get(async (req, res) => {
   try {
     const questions = await QuestionCtrl.list(req.query || {})
     const isActive = isActivePage(req)
-    res.render('edu/questions/index', { questions, isActive })
+    
+    // question._id --> URL
+    const imagePaths = questions.reduce((map, question) => {
+      map[question._id] = frontEndPath(question.imageSrc, edu.locals.frontEndRoot)
+      return map
+    }, {})
+
+    res.render('edu/questions/index', { questions, isActive, imagePaths })
   } catch (error) {
     res.status(500).send(`<h1>Internal Server Error</h1> <pre>${error}</pre>`)
   }

--- a/views/edu/questions/index.ejs
+++ b/views/edu/questions/index.ejs
@@ -5,7 +5,7 @@ UPchieve EDU Admin | Questions
 <% questions.forEach(question => { %>
 <div class="question-tile mt-4 mb-4 js-question-tile" id="<%= question._id %>">
   <div class="m-4 p-4 js-question-rendered">
-    <%- include('question-rendered', { question, questionId: question._id }) %>
+    <%- include('question-rendered', { question, questionId: question._id, frontEndRoot }) %>
   </div>
 
   <form class="m-4 p-4 js-question-form d-none" action="/edu/questions/<%=question._id %>" method="put" novalidate>

--- a/views/edu/questions/question-rendered.ejs
+++ b/views/edu/questions/question-rendered.ejs
@@ -22,7 +22,7 @@
 <div class="m-4 js-image">
   <img
     class="mw-100 w-50 <%= (!question.imageSrc) ? 'd-none' : '' %>"
-    src="<%= question.imageSrc %>" />
+    src="<%= imagePaths[question._id] %>" />
 </div>
 
 <div class="m-4 js-possibleAnswers">


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Resolve-issues-around-moving-between-localhost-8080-Vue-Vue-served-assets-namely-quiz-images-a-ce103c77ac4c4b3fa0e520d57d877953

Description
-----------
The logic for setting the `src` attribute of the quiz images in the EDU admin is changed to ensure that these images are displayed correctly when the application is being run in `dev` mode; the relative paths stored in the database are converted to absolute URLs with the hostname `localhost:8080` when the app is run in dev mode.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
