### PR TITLE
perform null check before trying to call user.populate

### DIFF
--- a/router/auth/passport.js
+++ b/router/auth/passport.js
@@ -12,7 +12,7 @@ passport.deserializeUser(function (id, done) {
     if (err || !user) {
       return done(err, user)
     }
-    
+
     user.populate('pastSessions').execPopulate((err, populatedUser) => {
       const parsedUser = populatedUser.parseProfile()
       done(err, parsedUser)

--- a/router/auth/passport.js
+++ b/router/auth/passport.js
@@ -9,10 +9,10 @@ passport.serializeUser(function (user, done) {
 
 passport.deserializeUser(function (id, done) {
   User.findById(id, function (err, user) {
-    if (err) {
+    if (err || !user) {
       return done(err, user)
     }
-
+    
     user.populate('pastSessions').execPopulate((err, populatedUser) => {
       const parsedUser = populatedUser.parseProfile()
       done(err, parsedUser)


### PR DESCRIPTION
Links
-----

Description
-----------
The code in `router/auth/passport.js` that puts the `pastSessions` into the deserialized User object breaks when a volunteer tries to sign up because it tries to call `populate()` on a null `user`. This PR checks the truthiness of the user before trying to call `populate()`.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [ ] Potentially confusing code has been explained with comments
- [ ] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
