### PR TITLE
Don't populate passwords and other sensitive fields by default

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -16,15 +16,15 @@ var userSchema = new mongoose.Schema({
       message: '{VALUE} is not a valid email'
     }
   },
-  password: String,
+  password: { type: String, select: false },
 
   verified: {
     type: Boolean,
     default: false
   },
-  verificationToken: String,
-  registrationCode: String,
-  passwordResetToken: String,
+  verificationToken: { type: String, select: false },
+  registrationCode: { type: String, select: false },
+  passwordResetToken: { type: String, select: false },
 
   // Profile data
   firstname: { type: String, required: [true, 'First name is required.'] },

--- a/router/auth/passport.js
+++ b/router/auth/passport.js
@@ -35,7 +35,12 @@ passport.use(
         }
 
         user.verifyPassword(password, function (err, user) {
-          User.findById(user._id, done)
+          if (err) {
+            done(err)
+          } else {
+            // pass the user to the callback without the password hash
+            User.findById(user._id, done)
+          }
         })
       })
     }

--- a/router/auth/passport.js
+++ b/router/auth/passport.js
@@ -26,7 +26,7 @@ passport.use(
       passwordField: 'password'
     },
     function (email, password, done) {
-      User.findOne({ email: email }, function (err, user) {
+      User.findOne({ email: email }, '+password', function (err, user) {
         if (err) {
           return done(err)
         }
@@ -35,7 +35,7 @@ passport.use(
         }
 
         user.verifyPassword(password, function (err, user) {
-          return done(err, user)
+          User.findById(user._id, done)
         })
       })
     }

--- a/router/auth/passport.js
+++ b/router/auth/passport.js
@@ -39,7 +39,8 @@ passport.use(
             done(err)
           } else {
             // pass the user to the callback without the password hash
-            User.findById(user._id, done)
+            user.password = undefined
+            done(null, user)
           }
         })
       })


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Don-t-send-password-hash-to-client-in-user-model-b32b7f3e9b414e4bb9fd7347c89ad6a9

Description
-----------
The server has been sending the password hash of the user to the client. The information is sent because, by default, all fields in a Mongoose schema are populated in queries. Since in the state before this PR there is no configured option in the `User` schema to change this default behavior, all fields are sent, including the `password` field.

Previous work has attempted to mitigate the issue by providing a separate method, `getProfile`, to extract from the original document and put into a new object only the fields that are necessary to send to the client. However, much of our code still sends clients the user document directly rather than calling the `getProfile` method, resulting in the sensitive fields being populated and sent to the client. Such a method call will also be easy to accidentally omit when future changes are made.

This PR defends against such vulnerabilities by specifying the option `select: false` for fields in the `User` schema containing sensitive information. By default, all fields in a Mongoose schema are populated in queries, but when the SchemaType option `select: false` is specified for a field, the field will be populated only when the projection is explicitly specified in the query. With this change, even if a contributor writing code for an endpoint were to forget about `getProfile()` and pass the  `User` document directly to the client, it will not contain fields for which `select: false` has been specified. Any code that retrieves the password from the document will now need to specify explicitly in the query that the `password` field is to be retrieved. 

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [ ] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
