### PR TITLE
Link to session in SMS messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1004,6 +1004,11 @@
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1970,7 +1975,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
@@ -3240,7 +3245,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -4123,7 +4128,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@sendgrid/mail": "^6.4.0",
     "async": "^1.5.0",
+    "base64url": "^3.0.1",
     "bcrypt": "3.0.4",
     "body-parser": "^1.18.3",
     "chalk": "^2.4.2",

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -182,14 +182,13 @@ function sendFailsafe (phoneNumber, name, options) {
     `regular volunteer${numOfRegularVolunteersNotified === 1 ? ' has' : 's have'} been notified.`
 
   const sessionUrl = getSessionUrl(options.sessionId)
-  
+
   let messageText
   if (desperate) {
     messageText = `Hi ${name}, student ${studentFirstname} ${studentLastname} ` +
       `from ${studentHighSchool} really needs your ${type} help ` +
       `on ${subtopic}. ${numberOfVolunteersNotifiedMessage} ` +
       `Please log in to app.upchieve.org and join the session ASAP!`
-      
   } else {
     messageText = `Hi ${name}, student ${studentFirstname} ${studentLastname} ` +
       `from ${studentHighSchool} has requested ${type} help ` +
@@ -199,7 +198,7 @@ function sendFailsafe (phoneNumber, name, options) {
   }
 
   messageText = messageText + ` ${sessionUrl}`
-  
+
   if (voice) {
     return sendVoiceMessage(phoneNumber, messageText)
   } else {

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -150,7 +150,7 @@ function getSessionUrl (sessionId) {
 
 function send (phoneNumber, name, subtopic, isTestUserRequest, sessionId) {
   const sessionUrl = getSessionUrl(sessionId)
-  const messageText = `Hi ${name}, a student just requested help in ${subtopic} at UPchieve. Please log in now to help them if you can! ${sessionUrl}`
+  const messageText = `Hi ${name}, a student needs help in ${subtopic} on UPchieve! Click here to start helping them now: ${sessionUrl}`
 
   return sendTextMessage(phoneNumber, messageText, isTestUserRequest)
 }

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -142,7 +142,7 @@ function sendVoiceMessage (phoneNumber, messageText) {
 }
 
 // the URL that the volunteer can use to join the session on the client
-function getSessionUrl(sessionId) {
+function getSessionUrl (sessionId) {
   const protocol = (config.NODE_ENV === 'production' ? 'https' : 'http')
   const sessionIdEncoded = base64url(Buffer.from(sessionId.toString(), 'hex'))
   return `${protocol}://${config.client.host}/s/${sessionIdEncoded}`

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -181,12 +181,15 @@ function sendFailsafe (phoneNumber, name, options) {
   const numberOfVolunteersNotifiedMessage = `${numOfRegularVolunteersNotified} ` +
     `regular volunteer${numOfRegularVolunteersNotified === 1 ? ' has' : 's have'} been notified.`
 
+  const sessionUrl = getSessionUrl(options.sessionId)
+  
   let messageText
   if (desperate) {
     messageText = `Hi ${name}, student ${studentFirstname} ${studentLastname} ` +
       `from ${studentHighSchool} really needs your ${type} help ` +
       `on ${subtopic}. ${numberOfVolunteersNotifiedMessage} ` +
       `Please log in to app.upchieve.org and join the session ASAP!`
+      
   } else {
     messageText = `Hi ${name}, student ${studentFirstname} ${studentLastname} ` +
       `from ${studentHighSchool} has requested ${type} help ` +
@@ -195,6 +198,8 @@ function sendFailsafe (phoneNumber, name, options) {
       `Please log in if you can to help them out.`
   }
 
+  messageText = messageText + ` ${sessionUrl}`
+  
   if (voice) {
     return sendVoiceMessage(phoneNumber, messageText)
   } else {
@@ -335,7 +340,8 @@ module.exports = {
               desperate: options && options.desperate,
               voice: options && options.voice,
               isTestUserRequest: options && options.isTestUserRequest,
-              numOfRegularVolunteersNotified: numOfRegularVolunteersNotified
+              numOfRegularVolunteersNotified: numOfRegularVolunteersNotified,
+              sessionId: session._id
             })
           // wait for recordNotification to succeed or fail before callback,
           // and don't break loop if only one message fails


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Send-notified-volunteers-a-link-to-the-session-c1aa2196964d4e67ba44a62ded6944c5
- Web repo PR: https://github.com/UPchieve/web/pull/226

Description
-----------
In the SMS messages to volunteers, a short URL is now sent that links to the session. The short URL is of the form:

```
https://app.upchieve.org/s/${sessionIdBase64}
```

Where `sessionIdBase64` is the MongoDB ObjectId of the session in base64url form instead of the hexadecimal form that we typically use. This short form of the URL should keep us within the 160-character limit on SMS messages for most users, but for a few volunteer names and subtopics, as well as test users who have the `[TEST USER]` notice prepended to the SMS message, the limit may be exceeded because of these additional characters, resulting in multiple SMS messages being sent from Twilio to be concatenated.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
