### PR TITLE
Fix: New Question page in EDU admin

### DIFF
--- a/views/edu/questions/question-rendered.ejs
+++ b/views/edu/questions/question-rendered.ejs
@@ -20,9 +20,11 @@
 </div>
 
 <div class="m-4 js-image">
+  <%if (locals.imagePaths) { %>
   <img
     class="mw-100 w-50 <%= (!question.imageSrc) ? 'd-none' : '' %>"
     src="<%= imagePaths[question._id] %>" />
+  <% } %>
 </div>
 
 <div class="m-4 js-possibleAnswers">


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/New-question-in-edu-admin-section-is-broken-8af7d28bd96e4a55b9a996624315f42b

Description
-----------
The New Question page in the EDU admin was broken because the EJS template referenced the `imagePaths` object used to determine the correct URL to display the question image in the current environment (i.e. `dev` or `production`), but there was no `imagePaths` object defined for a question that has not yet been created. This PR changes the template code to conditionally render the `img` element only if `imagePaths` is defined.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
