### PR TITLE
Track which user ends the session

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -50,7 +50,7 @@ module.exports = function (socketService) {
 
       this.verifySessionParticipant(session, user, new Error('Only session participants can end a session'))
 
-      await sessionService.endSession(session)
+      await sessionService.endSession(session, user)
 
       socketService.emitSessionEnd(options.sessionId)
 

--- a/models/Session.js
+++ b/models/Session.js
@@ -48,6 +48,11 @@ var sessionSchema = new mongoose.Schema({
   endedAt: {
     type: Date
   },
+  
+  endedBy: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
 
   volunteerJoinedAt: {
     type: Date
@@ -132,9 +137,14 @@ sessionSchema.methods.leaveUser = function (user, cb) {
   }
 }
 
-sessionSchema.methods.endSession = function () {
+sessionSchema.methods.endSession = function (user) {
   this.endedAt = new Date()
-  return this.save().then(() => console.log(`Ended session ${this._id} at ${this.endedAt}`))
+  
+  if (user) {
+    this.endedBy = user
+  }
+  
+  return this.save().then(() => console.log(`User ${user ? user._id + ' ' : ''}ended session ${this._id} at ${this.endedAt}`))
 }
 
 sessionSchema.methods.addNotifications = function (notificationsToAdd, cb) {

--- a/models/Session.js
+++ b/models/Session.js
@@ -48,7 +48,7 @@ var sessionSchema = new mongoose.Schema({
   endedAt: {
     type: Date
   },
-  
+
   endedBy: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User'
@@ -139,11 +139,11 @@ sessionSchema.methods.leaveUser = function (user, cb) {
 
 sessionSchema.methods.endSession = function (user) {
   this.endedAt = new Date()
-  
+
   if (user) {
     this.endedBy = user
   }
-  
+
   return this.save().then(() => console.log(`User ${user ? user._id + ' ' : ''}ended session ${this._id} at ${this.endedAt}`))
 }
 

--- a/services/SessionService.js
+++ b/services/SessionService.js
@@ -27,6 +27,6 @@ module.exports = {
       this.addPastSession(volunteer, session)
     }
 
-    await session.endSession()
+    await session.endSession(user)
   }
 }

--- a/services/SocketService.js
+++ b/services/SocketService.js
@@ -74,7 +74,7 @@ module.exports = function (io) {
         { path: 'student', select: 'firstname isVolunteer' },
         { path: 'volunteer', select: 'firstname isVolunteer' }
       ]
-      
+
       const session = await Session.findById(sessionId)
         .populate(populateOptions)
         .exec()


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Keep-track-of-which-user-ends-a-session-f802042f32a2497786103bdbd10bb900

Description
-----------
A new field `endedBy` is added to the Session model schema so that a reference to the user that ended the session can be stored in the database.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
