### PR TITLE
Fix: TypeError in api/user endpoint

### DIFF
--- a/router/api/user.js
+++ b/router/api/user.js
@@ -62,12 +62,12 @@ module.exports = function (router) {
           pastSessions: data.pastSessions
         }
       },
-      function (err, user) {
+      function (err, parsedUser) {
         if (err) {
           res.json({ err: err })
         } else {
           res.json({
-            user: user
+            user: parsedUser
           })
         }
       }

--- a/router/api/user.js
+++ b/router/api/user.js
@@ -67,7 +67,7 @@ module.exports = function (router) {
           res.json({ err: err })
         } else {
           res.json({
-            user: user.parseProfile()
+            user: user
           })
         }
       }


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Error-message-appears-when-saving-volunteer-profile-data-even-though-save-is-successful-b58618d300bd4889aac307c74d7ebc10
- Issue: https://github.com/UPchieve/web/issues/274

Description
-----------
The `api/user` endpoint no longer tries to call a nonexistent `parseProfile` function on the object that is returned by `parseProfile` and passed to the endpoint, so volunteers saving their profile data will not see an error message.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [ ] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
