### PR TITLE
Math-Only Partner Orgs

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -34,7 +34,8 @@ module.exports = {
     },
     foobar: {
       name: 'Foo Bar & Co',
-      requiredEmailDomains: ['example.org', 'example.net']
+      requiredEmailDomains: ['example.org', 'example.net'],
+      mathCoachingOnly: true
     }
   },
 

--- a/models/User.js
+++ b/models/User.js
@@ -70,7 +70,7 @@ var userSchema = new mongoose.Schema({
   verificationToken: { type: String, select: false },
   passwordResetToken: { type: String, select: false },
   registrationCode: { type: String, select: false },
-  volunteerPartnerOrg: { type: String, select: false },
+  volunteerPartnerOrg: String,
 
   // Profile data
   firstname: { type: String, required: [true, 'First name is required.'] },
@@ -483,7 +483,8 @@ userSchema.methods.parseProfile = function () {
     certifications: this.certifications,
     phonePretty: this.phonePretty,
     numPastSessions: this.numPastSessions,
-    numVolunteerSessionHours: this.numVolunteerSessionHours
+    numVolunteerSessionHours: this.numVolunteerSessionHours,
+    mathCoachingOnly: this.mathCoachingOnly
   }
 }
 
@@ -673,6 +674,15 @@ userSchema.virtual('numVolunteerSessionHours')
     const hoursDiff = (totalMilliseconds / 3600000).toFixed(2)
 
     return hoursDiff
+  })
+
+userSchema.virtual('mathCoachingOnly')
+  .get(function () {
+    if (!this.isVolunteer) return null
+    if (!this.volunteerPartnerOrg) return false
+
+    const orgManifest = config.orgManifests[this.volunteerPartnerOrg]
+    return !!orgManifest && !!orgManifest['mathCoachingOnly']
   })
 
 // Static method to determine if a registration code is valid


### PR DESCRIPTION
Links
-----
- Web repo PR: https://github.com/UPchieve/web/pull/275

Description
-----------
- Add support for restricting certain volunteers to math tutoring (no college counseling)


_Note_: This is a bit hacky & not generalized to allow any/all topics to be blacklisted, but:
- we're under a time crunch
- the training view needs major refactoring -- it's not worth wrestling with right now
- restrictions by coaching topic likely won't be a common demand of partner orgs in the near future

Developer self-review checklist
-------------------------------
- [ ] Task's requirements have been fully addressed
- [ ] Potentially confusing code has been explained with comments
- [ ] Posted a link to this PR on the Notion task
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] All new code complies with our ESLint standards
