### PR TITLE
Don't join sockets to rooms corresponding to terminated sessions

### DIFF
--- a/services/SocketService.js
+++ b/services/SocketService.js
@@ -21,7 +21,8 @@ module.exports = function (io) {
         $or: [
           { student: userId },
           { volunteer: userId }
-        ]
+        ],
+        endedAt: { $exists: false }
       }, '_id')
         .exec()
 


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/165

Description
-----------
When sockets were connected, they automatically were joined to rooms corresponding to all session IDs in which the user was ever a participant. This is changed so that only rooms corresponding to active sessions are joined.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
