### PR TITLE
Record failed join attempts in the Session model

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -88,6 +88,8 @@ module.exports = function (socketService) {
           twilioService.stopNotifications(session)
         }
       } catch (err) {
+        // so client knows whether the session has ended or was fulfilled
+        err.endedAt = session.endedAt
         socketService.bump(socket, err)
       }
     },

--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -88,9 +88,8 @@ module.exports = function (socketService) {
           twilioService.stopNotifications(session)
         }
       } catch (err) {
-        // so client knows whether the session has ended or was fulfilled
-        err.endedAt = session.endedAt
-        socketService.bump(socket, err)
+        // data passed so client knows whether the session has ended or was fulfilled
+        socketService.bump(socket, { endedAt: session.endedAt }, err)
       }
     },
 

--- a/services/SocketService.js
+++ b/services/SocketService.js
@@ -97,7 +97,7 @@ module.exports = function (io) {
       console.log('Could not join session')
       console.log(err)
       io.emit('error', err.toString())
-      socket.emit('bump', err.toString())
+      socket.emit('bump', err, err.toString())
     },
 
     deliverMessage: function (message, sessionId) {

--- a/services/SocketService.js
+++ b/services/SocketService.js
@@ -93,11 +93,11 @@ module.exports = function (io) {
       }
     },
 
-    bump: function (socket, err) {
+    bump: function (socket, data, err) {
       console.log('Could not join session')
       console.log(err)
       io.emit('error', err.toString())
-      socket.emit('bump', err, err.toString())
+      socket.emit('bump', data, err.toString())
     },
 
     deliverMessage: function (message, sessionId) {


### PR DESCRIPTION
Links
-----
- Issue: UPchieve/web#278

Description
-----------
- A new property `failedJoins` is added to the Session model that keeps an array of user IDs that have tried to join the session but failed either because the session was fulfilled or was ended.
- The logic for joining a user to a session is changed so that an error is thrown if the session has ended, regardless of whether a volunteer has joined.
- The logic for sending the bump socket message is changed to allow the value of `endedAt` to be sent along with the message so that the client knows whether the session has ended.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
