### PR TITLE
Only populate pastSessions when stats are needed

### DIFF
--- a/router/api/user.js
+++ b/router/api/user.js
@@ -16,7 +16,10 @@ module.exports = function (router) {
     }
 
     // Return volunteer user
-    req.user.populateForVolunteerStats().execPopulate().then(populatedUser => {
+    const userPromise = req.query.withStats
+      ? req.user.populateForVolunteerStats().execPopulate()
+      : Promise.resolve(req.user)
+    return userPromise.then(populatedUser => {
       return res.json({
         user: populatedUser.parseProfile()
       })


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/284
- Web repo PR: https://github.com/UPchieve/web/pull/286

Description
-----------
- `pastSessions` will no longer be populated by the `/api/user` endpoint unless a query parameter is specified. This will improve performance for users who have large numbers of past sessions

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
