### PR TITLE
SMS session link replies

### DIFF
--- a/router/twiml/index.js
+++ b/router/twiml/index.js
@@ -2,6 +2,7 @@ const express = require('express')
 const twilio = require('twilio')
 
 const VoiceResponse = twilio.twiml.VoiceResponse
+const MessagingResponse = require('twilio').twiml.MessagingResponse
 
 const config = require('../../config')
 
@@ -28,6 +29,31 @@ module.exports = function (app) {
 
     res.type('text/xml')
     res.send(twiml.toString())
+  })
+
+  router.post('/incoming-sms', function (req, res, next) {
+    const twiml = new MessagingResponse()
+
+    console.log(req.body)
+
+    const incomingMessage = req.body.Body
+
+    if (incomingMessage === 'YES') {
+      /**
+       * Find session that this user was notified about and reply with its link
+       * Or if they weren't notified recently (~1 hr), say so
+       * If someone already joined the session, say so
+       * If the student cancelled the session, say so
+       */
+      twiml.message('TODO: send session link')
+    } else if (incomingMessage === 'HELP') {
+      twiml.message('TODO: explain msg options (i.e. YES/HELP/STOP)')
+    } else {
+      twiml.message('as a robot, i dont understand. plz email contact@upchieve.org')
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/xml' })
+    res.end(twiml.toString())
   })
 
   app.use('/twiml', router)

--- a/router/twiml/index.js
+++ b/router/twiml/index.js
@@ -1,24 +1,27 @@
 const express = require('express')
 const twilio = require('twilio')
+const _ = require('lodash')
 
 const VoiceResponse = twilio.twiml.VoiceResponse
 const MessagingResponse = require('twilio').twiml.MessagingResponse
 
 const config = require('../../config')
+const twilioService = require('../../services/twilio')
+const User = require('../../models/User')
 
-// These routes are called by Twilio to receive TwiML instructions for
-// voice calls. The Twilio API for voice calling requires that a URL be
-// specified to obtain the TwiML code it needs to generate the voice message.
-// In order to put our message content into a voice call we give Twilio
-// a URL pointing to our own server, which contains the message text encoded
-// in it. When the call is answered Twilio sends a request to this
-// URL, and our server responds with TwiML containing the decoded message text
-// and the configured voice for the text-to-speech conversion.
 module.exports = function (app) {
   console.log('TwiML module')
 
   const router = new express.Router()
 
+  // This route is called by Twilio to receive TwiML instructions for
+  // voice calls. The Twilio API for voice calling requires that a URL be
+  // specified to obtain the TwiML code it needs to generate the voice message.
+  // In order to put our message content into a voice call we give Twilio
+  // a URL pointing to our own server, which contains the message text encoded
+  // in it. When the call is answered, Twilio sends a request to this
+  // URL, and our server responds with TwiML containing the decoded message text
+  // and the configured voice for the text-to-speech conversion.
   router.post('/message/:message', function (req, res, next) {
     const message = decodeURIComponent(req.params.message)
     console.log('Making TwiML for voice message')
@@ -31,25 +34,63 @@ module.exports = function (app) {
     res.send(twiml.toString())
   })
 
-  router.post('/incoming-sms', function (req, res, next) {
+  /**
+   * This route handles SMS messages sent to our Twilio numbers
+   */
+  router.post('/incoming-sms', async function (req, res, next) {
     const twiml = new MessagingResponse()
 
-    console.log(req.body)
-
     const incomingMessage = req.body.Body
+    const incomingPhoneNumber = req.body.From
 
-    if (incomingMessage === 'YES') {
-      /**
-       * Find session that this user was notified about and reply with its link
-       * Or if they weren't notified recently (~1 hr), say so
-       * If someone already joined the session, say so
-       * If the student cancelled the session, say so
-       */
-      twiml.message('TODO: send session link')
-    } else if (incomingMessage === 'HELP') {
-      twiml.message('TODO: explain msg options (i.e. YES/HELP/STOP)')
+    if (!incomingPhoneNumber) return res.json({ err: 'Error: Missing phone number' })
+
+    /**
+     * If a volunteer responds "Yes" to a text notification, send
+     * them a link to the session that they were notified about.
+     */
+    const yesRegex = /\b(yes|yeah|yea|yess|yesss|ye|ya|yaa|yee|y|yeh|yah|sure)\b/gmi
+    const isYesMessage = !!incomingMessage.match(yesRegex)
+
+    if (isYesMessage) {
+      try {
+        /**
+         * 1. Find the user by their phone number
+         * 2. Populate their most recent notification
+         * 3. Populate that notification's session
+         */
+        const populatedUser = await User.findOne({ phone: incomingPhoneNumber })
+          .populate({
+            path: 'volunteerLastNotification',
+            populate: {
+              path: 'session',
+              select: '_id volunteerJoinedAt endedAt'
+            }
+          })
+
+        // Get the session if it exists, or else an empty object
+        const session = _.get(populatedUser, 'volunteerLastNotification.session', {})
+
+        if (!session._id) {
+          // Handle: No session found
+          twiml.message('Error: No session found. You can try joining the session from the dashboard at app.upchieve.org')
+        } else if (session.volunteerJoinedAt) {
+          // Handle: Different volunteer already joined
+          twiml.message('A volunteer has already joined this session')
+        } else if (session.endedAt) {
+          // Handle: Student already ended the session
+          twiml.message('The student has cancelled their help request')
+        } else {
+          // Handle: No issues, so send the session URL
+          const sessionUrl = twilioService.getSessionUrl(session._id)
+          twiml.message(sessionUrl)
+        }
+      } catch (err) {
+        return res.json({ err: err.toString() })
+      }
     } else {
-      twiml.message('as a robot, i dont understand. plz email contact@upchieve.org')
+      // Handle: Unknown message intent
+      twiml.message('Hmm, I don\'t understand. Please send questions to contact@upchieve.org')
     }
 
     res.writeHead(200, { 'Content-Type': 'text/xml' })

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -4,7 +4,6 @@ var twilio = require('twilio')
 var moment = require('moment-timezone')
 const client = twilio(config.accountSid, config.authToken)
 const base64url = require('base64url')
-const _ = require('lodash')
 
 const Session = require('../models/Session')
 const Notification = require('../models/Notification')
@@ -215,10 +214,7 @@ const notifyRegular = async function (session) {
     const isTestUserRequest = session.student.isTestUser
 
     // format message
-    const callToActionWordings = ['Start', 'Click here to start', 'Click this link to start', 'Tap here to start', 'Follow this link to start']
-    const callToAction = _.sample(callToActionWordings)
-    const sessionUrl = getSessionUrl(session._id)
-    const messageText = `Hi ${name}, a student needs help in ${subtopic} on UPchieve! ${callToAction} helping them now: ${sessionUrl}`
+    const messageText = `Hi ${name}, a student needs help in ${subtopic} on UPchieve! Respond YES if you're available.`
 
     const sendPromise = sendTextMessage(phoneNumber, messageText, isTestUserRequest)
 
@@ -359,6 +355,10 @@ function getSessionTimeoutFor (session) {
 }
 
 module.exports = {
+  getSessionUrl: function (sessionId) {
+    return getSessionUrl(sessionId)
+  },
+
   // get total number of available, non-failsafe volunteers in the database
   // return Promise that resolves to count
   countAvailableVolunteersInDb: function (subtopic, options) {


### PR DESCRIPTION
Description
-----------
- In volunteer text notifications, stop sending a link to the session
- Only send the link once a volunteer replies "Yes"
- Handle this reply via a Twilio webhook endpoint

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
