### PR TITLE
Fix volunteer coverage

### DIFF
--- a/controllers/VolunteersCtrl.js
+++ b/controllers/VolunteersCtrl.js
@@ -56,7 +56,6 @@ module.exports = {
 
     const volunteerQuery = {
       isVolunteer: true,
-      hasSchedule: true,
       [certifiedSubjectQuery]: true,
       availability: { $exists: true },
       isFakeUser: false,

--- a/controllers/VolunteersCtrl.js
+++ b/controllers/VolunteersCtrl.js
@@ -13,11 +13,9 @@ function aggregateAvailabilities (availability, aggAvailabilities) {
       // create headers based on the user's availability object
       if (!aggAvailabilities.daysOfWeek) {
         aggAvailabilities.daysOfWeek = Object.keys(availability)
-        aggAvailabilities.daysOfWeek.shift() // gets rid of $init enum param
       }
       if (!aggAvailabilities.timesOfDay) {
         aggAvailabilities.timesOfDay = Object.keys(availability[day])
-        aggAvailabilities.timesOfDay.shift() // gets rid of $init enum param
       }
       // gets corresponding day and time index inorder to store in aggAvailabilities table
       let dayIndex = aggAvailabilities.daysOfWeek.indexOf(day)
@@ -74,7 +72,10 @@ module.exports = {
         return callback(null, err)
       } else {
         aggAvailabilities = users.reduce(function (aggAvailabilities, user) {
-          return aggregateAvailabilities(user.availability, aggAvailabilities)
+          // Convert the user's availability prop from Mongoose object to plain object
+          const userAvailability = user.availability.toObject()
+
+          return aggregateAvailabilities(userAvailability, aggAvailabilities)
         }, aggAvailabilities)
         aggAvailabilities = findMinAndMax(aggAvailabilities)
         return callback(aggAvailabilities, null)

--- a/models/User.js
+++ b/models/User.js
@@ -313,7 +313,6 @@ userSchema.methods.parseProfile = function () {
     phone: this.phone,
     preferredContactMethod: this.preferredContactMethod,
     availability: this.availability,
-    hasSchedule: this.hasSchedule,
     timezone: this.timezone,
 
     highschoolName: this.highschoolName,

--- a/tests/unit/models/Message.test.js
+++ b/tests/unit/models/Message.test.js
@@ -231,7 +231,6 @@ const user = new User({
       '11p': true
     }
   },
-  hasSchedule: false,
   timezone: "timezone",
   pastSessions: null
 })

--- a/tests/unit/models/User.test.js
+++ b/tests/unit/models/User.test.js
@@ -228,7 +228,6 @@ const goodUser = new User({
       '11p': true
     }
   },
-  hasSchedule: false,
   timezone: "EST",
   pastSessions: null
 })


### PR DESCRIPTION
Description
-----------
- The volunteer coverage admin tool broke when we started using a separate Mongoose schema for user availability. Calling `Object.keys(<user.availability>)` was returning a bunch of internal Mongoose object props, but we just want the keys for the days of the week.
- This PR also removes some leftover references to `User.hasSchedule`, a property that is no longer used.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
