### PR TITLE
Remove async session participant verification in draw sockets

### DIFF
--- a/router/api/sockets.js
+++ b/router/api/sockets.js
@@ -189,10 +189,13 @@ module.exports = function (io, sessionStore) {
     socket.on('dragStart', async function (data) {
       if (!data || !data.sessionId) return
 
-      await sessionCtrl.verifySessionParticipantBySessionId(
-        data.sessionId,
-        socket.request.user,
-        whiteboardAccessError)
+      /**
+       * For now, async session participant verification is disabled for this socket to
+       * prevent drawing data from being sent out-of-order (which caused jagged lines)
+       *
+       * @todo: Verify session participants synchronously with an in-memory object that
+       * maps session IDs to user IDs
+       */
 
       socket.broadcast.to(data.sessionId).emit('dstart', {
         x: data.x,
@@ -204,10 +207,13 @@ module.exports = function (io, sessionStore) {
     socket.on('dragAction', async function (data) {
       if (!data || !data.sessionId) return
 
-      await sessionCtrl.verifySessionParticipantBySessionId(
-        data.sessionId,
-        socket.request.user,
-        whiteboardAccessError)
+      /**
+       * For now, async session participant verification is disabled for this socket to
+       * prevent drawing data from being sent out-of-order (which caused jagged lines)
+       *
+       * @todo: Verify session participants synchronously with an in-memory object that
+       * maps session IDs to user IDs
+       */
 
       socket.broadcast.to(data.sessionId).emit('drag', {
         x: data.x,
@@ -219,10 +225,13 @@ module.exports = function (io, sessionStore) {
     socket.on('dragEnd', async function (data) {
       if (!data || !data.sessionId) return
 
-      await sessionCtrl.verifySessionParticipantBySessionId(
-        data.sessionId,
-        socket.request.user,
-        whiteboardAccessError)
+      /**
+       * For now, async session participant verification is disabled for this socket to
+       * prevent drawing data from being sent out-of-order (which caused jagged lines)
+       *
+       * @todo: Verify session participants synchronously with an in-memory object that
+       * maps session IDs to user IDs
+       */
 
       socket.broadcast.to(data.sessionId).emit('dend', {
         x: data.x,


### PR DESCRIPTION
Description
-----------
- The async session participant checks inside drawing-related sockets were causing issues where packets could be sent out-of-order, causing jagged lines to be drawn on the whiteboard

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
