### PR TITLE
Use appropriate HTTP status codes

### DIFF
--- a/router/api/session.js
+++ b/router/api/session.js
@@ -56,7 +56,7 @@ module.exports = function (router, io) {
       const session = await Session.findById(sessionId).exec()
 
       if (!session) {
-        res.json({
+        res.status(404).json({
           err: 'No session found'
         })
       } else {
@@ -77,7 +77,7 @@ module.exports = function (router, io) {
     try {
       const currentSession = await Session.current(userId)
       if (!currentSession) {
-        res.json({ err: 'No current session' })
+        res.status(404).json({ err: 'No current session' })
       } else {
         res.json({
           sessionId: currentSession._id,

--- a/router/api/user.js
+++ b/router/api/user.js
@@ -3,7 +3,7 @@ var UserCtrl = require('../../controllers/UserCtrl')
 module.exports = function (router) {
   router.route('/user').get(function (req, res) {
     if (!req.user) {
-      return res.json({
+      return res.status(401).json({
         err: 'Client has no authenticated session'
       })
     }

--- a/router/api/verify.js
+++ b/router/api/verify.js
@@ -5,7 +5,7 @@ module.exports = function (router) {
     var userId = req.user && req.user._id
 
     if (!userId) {
-      return res.json({
+      return res.status(401).json({
         err: 'Must be authenticated to send verification email'
       })
     }

--- a/router/auth/index.js
+++ b/router/auth/index.js
@@ -78,7 +78,7 @@ module.exports = function (app) {
     var password = req.body.password
 
     if (!email || !password) {
-      return res.json({
+      return res.status(422).json({
         err: 'Must supply an email and password for registration'
       })
     }
@@ -86,7 +86,7 @@ module.exports = function (app) {
     // Verify password for registration
     let checkResult = checkPassword(password)
     if (checkResult !== true) {
-      return res.json({
+      return res.status(422).json({
         err: checkResult
       })
     }
@@ -97,7 +97,7 @@ module.exports = function (app) {
           checked: true
         })
       } else {
-        return res.json({
+        return res.status(409).json({
           err: 'The email address you entered is already in use'
         })
       }
@@ -130,13 +130,13 @@ module.exports = function (app) {
     var terms = req.body.terms
 
     if (!terms) {
-      return res.json({
+      return res.status(422).json({
         err: 'Must accept the user agreement'
       })
     }
 
     if (!email || !password) {
-      return res.json({
+      return res.status(422).json({
         err: 'Must supply an email and password for registration'
       })
     }
@@ -147,7 +147,7 @@ module.exports = function (app) {
       const orgManifest = allOrgManifests[volunteerPartnerOrg]
 
       if (!orgManifest) {
-        return res.json({
+        return res.status(422).json({
           err: 'Invalid volunteer partner organization'
         })
       }
@@ -158,7 +158,7 @@ module.exports = function (app) {
       if (partnerOrgDomains && partnerOrgDomains.length) {
         const userEmailDomain = email.split('@')[1]
         if (partnerOrgDomains.indexOf(userEmailDomain) === -1) {
-          return res.json({
+          return res.status(422).json({
             err: 'Invalid email domain for volunteer partner organization'
           })
         }
@@ -168,7 +168,7 @@ module.exports = function (app) {
     // Verify password for registration
     let checkResult = checkPassword(password)
     if (checkResult !== true) {
-      return res.json({
+      return res.status(422).json({
         err: checkResult
       })
     }
@@ -300,7 +300,7 @@ module.exports = function (app) {
     const orgId = req.query.orgId
 
     if (!orgId) {
-      return res.json({
+      return res.status(422).json({
         err: 'Missing orgId query string'
       })
     }
@@ -308,7 +308,7 @@ module.exports = function (app) {
     const allOrgManifests = config.orgManifests
 
     if (!allOrgManifests) {
-      return res.json({
+      return res.status(422).json({
         err: 'Missing orgManifests in config'
       })
     }
@@ -316,7 +316,7 @@ module.exports = function (app) {
     const orgManifest = allOrgManifests[orgId]
 
     if (!orgManifest) {
-      return res.json({
+      return res.status(404).json({
         err: `No org manifest found for orgId "${orgId}"`
       })
     }
@@ -328,7 +328,7 @@ module.exports = function (app) {
     var code = req.body.code
     console.log(code)
     if (!code) {
-      res.json({
+      res.status(422).json({
         err: 'No registration code given'
       })
       return
@@ -349,7 +349,7 @@ module.exports = function (app) {
   router.post('/reset/send', function (req, res) {
     var email = req.body.email
     if (!email) {
-      return res.json({
+      return res.status(422).json({
         err: 'Must supply an email for password reset'
       })
     }
@@ -381,26 +381,26 @@ module.exports = function (app) {
     var token = req.body.token
 
     if (!token) {
-      return res.json({
+      return res.status(422).json({
         err: 'No password reset token given'
       })
     } else if (!email || !password) {
-      return res.json({
+      return res.status(422).json({
         err: 'Must supply an email and password for password reset'
       })
     } else if (!newpassword) {
-      return res.json({
+      return res.status(422).json({
         err: 'Must reenter password for password reset'
       })
     } else if (newpassword !== password) {
-      return res.json({
+      return res.status(422).json({
         err: 'Passwords do not match'
       })
     }
 
     // Verify password for password reset
     if (password.length < 8) {
-      return res.json({
+      return res.status(422).json({
         err: 'Password must be 8 characters or longer'
       })
     }
@@ -419,17 +419,17 @@ module.exports = function (app) {
     }
 
     if (numUpper === 0) {
-      return res.json({
+      return res.status(422).json({
         err: 'Password must contain at least one uppercase letter'
       })
     }
     if (numLower === 0) {
-      return res.json({
+      return res.status(422).json({
         err: 'Password must contain at least one lowercase letter'
       })
     }
     if (numNumber === 0) {
-      return res.json({
+      return res.status(422).json({
         err: 'Password must contain at least one number'
       })
     }

--- a/router/twiml/index.js
+++ b/router/twiml/index.js
@@ -43,7 +43,7 @@ module.exports = function (app) {
     const incomingMessage = req.body.Body
     const incomingPhoneNumber = req.body.From
 
-    if (!incomingPhoneNumber) return res.json({ err: 'Error: Missing phone number' })
+    if (!incomingPhoneNumber) return res.status(422).json({ err: 'Error: Missing phone number' })
 
     /**
      * If a volunteer responds "Yes" to a text notification, send


### PR DESCRIPTION
Links
-----
- Web repo PR: https://github.com/UPchieve/web/pull/314

Description
-----------
- API endpoints were using the HTTP 200 status code for error conditions. The responses are now updated to include appropriate HTTP status codes.
- HTTP 500 error codes are intentionally left out so as to avoid conflicts with https://github.com/UPchieve/server/pull/187

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
