### PR TITLE
Don't await notification kickoff during session creation

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -29,8 +29,8 @@ module.exports = function (socketService) {
 
       socketService.emitNewSession(savedSession)
 
-      await twilioService.beginRegularNotifications(savedSession)
-      await twilioService.beginFailsafeNotifications(savedSession)
+      twilioService.beginRegularNotifications(savedSession)
+      twilioService.beginFailsafeNotifications(savedSession)
 
       return savedSession
     },


### PR DESCRIPTION
Description
-----------
- Don't await notification kickoff during session creation
- Dramatically speeds up the client side transition into session view, e.g. from `/session/math/algebra` to `/session/math/algebra/5e1f851d5c06132017e352c7`

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
