### PR TITLE
Use passport for calendar authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,6 @@ where `ORG_ID` is the key name of the partner organization stored in `config.js`
 
 ```json
 {
-  "userid": "String",
   "availability": "String"
 }
 ```

--- a/router/api/calendar.js
+++ b/router/api/calendar.js
@@ -3,7 +3,7 @@ var CalendarCtrl = require('../../controllers/CalendarCtrl')
 module.exports = function (router) {
   router.post('/calendar/save', function (req, res) {
     CalendarCtrl.updateAvailability(
-      { userid: req.body.userid, availability: req.body.availability },
+      { userid: req.user._id, availability: req.body.availability },
       function (err, avail) {
         if (err) {
           res.json({ err: err })
@@ -17,7 +17,7 @@ module.exports = function (router) {
   })
   router.post('/calendar/tz/save', function (req, res) {
     CalendarCtrl.updateTimezone(
-      { userid: req.body.userid, tz: req.body.tz },
+      { userid: req.user._id, tz: req.body.tz },
       function (err, tz) {
         if (err) {
           res.json({ err: err })


### PR DESCRIPTION
Links
-----

Description
-----------
- The `/api/calendar/save` and `/api/calendar/tz/save` endpoints are updated to obtain the ID of the user from Passport instead of relying on the client to send the correct user ID.

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
