### PR TITLE
Use passport for training authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,6 @@ where `ORG_ID` is the key name of the partner organization stored in `config.js`
 
 ```json
 {
-  "userid": "String",
   "idAnswerMap": "String",
   "category": "String"
 }

--- a/router/api/training.js
+++ b/router/api/training.js
@@ -19,7 +19,7 @@ module.exports = function (router) {
   router.post('/training/score', function (req, res) {
     TrainingCtrl.getQuizScore(
       {
-        userid: req.body.userid,
+        userid: req.user._id,
         idAnswerMap: req.body.idAnswerMap,
         category: req.body.category
       },


### PR DESCRIPTION
Links
-----

Description
-----------
- The `/api/training/score` endpoint is updated to obtain the user ID from passport instead of relying on the client to send the correct ID.

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
