### PR TITLE
Capture only errors that exist in Session.saveWhiteboardUrl

### DIFF
--- a/models/Session.js
+++ b/models/Session.js
@@ -107,7 +107,9 @@ sessionSchema.methods.saveWhiteboardUrl = function (whiteboardUrl, cb) {
         cb(null, session.whiteboardUrl)
       }
     } else {
-      Sentry.captureException(err)
+      if (err) {
+        Sentry.captureException(err)
+      }
     }
   })
 }


### PR DESCRIPTION
Links
-----

Description
-----------
- In `Session.saveWhiteboardUrl`, when there is no callback passed the error parameter is always captured, even if it's `null` or `undefined` meaning there was no error. This PR fixes that behavior.

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
