### PR TITLE
Calendar speedup

### DIFF
--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -1,45 +1,30 @@
-var User = require('../models/User')
-
 module.exports = {
   updateAvailability: function(options, callback) {
-    var userid = options.userid
-    var availability = options.availability
-    User.findOne({ _id: userid }, function(err, user) {
+    const user = options.user
+    const availability = options.availability
+
+    user.availability.set(availability)
+
+    user.save(function(err, user) {
       if (err) {
-        return callback(err)
+        callback(err, null)
+      } else {
+        callback(null, availability)
       }
-      if (!user) {
-        return callback(new Error('No account with that id found.'))
-      }
-      user.availability.set(availability)
-      user.save(function(err, user) {
-        if (err) {
-          callback(err, null)
-        } else {
-          callback(null, availability)
-        }
-      })
     })
   },
 
   updateTimezone: function(options, callback) {
-    var userid = options.userid
-    var tz = options.tz
-    User.findOne({ _id: userid }, function(err, user) {
+    const user = options.user
+    const tz = options.tz
+
+    user.timezone = tz
+    user.save(function(err, user) {
       if (err) {
-        return callback(err)
+        callback(err, null)
+      } else {
+        callback(null, tz)
       }
-      if (!user) {
-        return callback(new Error('No account with that id found.'))
-      }
-      user.timezone = tz
-      user.save(function(err, user) {
-        if (err) {
-          callback(err, null)
-        } else {
-          callback(null, tz)
-        }
-      })
     })
   }
 }

--- a/router/api/calendar.js
+++ b/router/api/calendar.js
@@ -3,7 +3,7 @@ var CalendarCtrl = require('../../controllers/CalendarCtrl')
 module.exports = function(router) {
   router.post('/calendar/save', function(req, res, next) {
     CalendarCtrl.updateAvailability(
-      { userid: req.user._id, availability: req.body.availability },
+      { user: req.user, availability: req.body.availability },
       function(err, avail) {
         if (err) {
           next(err)
@@ -16,17 +16,17 @@ module.exports = function(router) {
     )
   })
   router.post('/calendar/tz/save', function(req, res, next) {
-    CalendarCtrl.updateTimezone(
-      { userid: req.user._id, tz: req.body.tz },
-      function(err, tz) {
-        if (err) {
-          next(err)
-        } else {
-          res.json({
-            msg: 'Timezone saved'
-          })
-        }
+    CalendarCtrl.updateTimezone({ user: req.user, tz: req.body.tz }, function(
+      err,
+      tz
+    ) {
+      if (err) {
+        next(err)
+      } else {
+        res.json({
+          msg: 'Timezone saved'
+        })
       }
-    )
+    })
   })
 }


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/189

Description
-----------
- Instead of sending only the user ID to the controller, unnecessarily requiring the controller to fetch the user from the database, the user object from passport is sent to the controller so that the controller does not have to retrieve the user from the database in order to save the new availability data.
- This improves performance somewhat, but calendar save still takes 2-4 seconds on staging. This is probably due in part to the fact that two API endpoints, `/api/calendar/save` and `/api/calendar/tz/save`, are called for the single user action of clicking "Save", and they both require passport authentication. We may want to consider combining these into one API endpoint so that authentication only needs to be performed once.
- Another contributing factor to the slowdown may be the call to `user.availability.set` in `CalendarCtrl.updateAvailability`. This function ensures that empty objects do not cause data to be erased, but also appears to take a significant amount of time (about 0.5-1 second).

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
