### PR TITLE
Faster validation for calendar API

### DIFF
--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -11,17 +11,19 @@ module.exports = {
 
     // verify that all of the day-of-week and time-of-day properties are defined on the
     // new availability object
-    if (Object.keys(user.availability.toObject())
-      .some((key) => {
-        if (typeof(availability[key]) === "undefined") {
+    if (
+      Object.keys(user.availability.toObject()).some(key => {
+        if (typeof availability[key] === 'undefined') {
           // day-of-week property needs to be defined
           return true
         }
-        
+
         // time-of-day properties also need to be defined
-        return Object.keys(user.availability[key].toObject())
-          .some((key2) => typeof(availability[key][key2]) === "undefined")
-      })) {
+        return Object.keys(user.availability[key].toObject()).some(
+          key2 => typeof availability[key][key2] === 'undefined'
+        )
+      })
+    ) {
       return callback(new Error('Availability object missing required keys'))
     }
 

--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -3,7 +3,29 @@ module.exports = {
     const user = options.user
     const availability = options.availability
 
-    user.availability.set(availability)
+    // verify that availability object is defined and not null
+    if (!availability) {
+      // early exit
+      return callback(new Error('No availability object specified'))
+    }
+
+    // verify that all of the day-of-week and time-of-day properties are defined on the
+    // new availability object
+    if (Object.keys(user.availability.toObject())
+      .some((key) => {
+        if (typeof(availability[key]) === "undefined") {
+          // day-of-week property needs to be defined
+          return true
+        }
+        
+        // time-of-day properties also need to be defined
+        return Object.keys(user.availability[key].toObject())
+          .some((key2) => typeof(availability[key][key2]) === "undefined")
+      })) {
+      return callback(new Error('Availability object missing required keys'))
+    }
+
+    user.availability = availability
     user.availabilityLastModifiedAt = new Date().toISOString()
     user.save(function(err, user) {
       if (err) {


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/215

Description
-----------
- Instead of using the Mongoose `set` function to set the calendar availability object, the code explicitly validates the input object against the keys in the existing availability document, and if any of them are missing from the new object, the availability document is not updated. This process is faster than using the `set` function.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
