### PR TITLE
Combine calendar API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,8 +275,8 @@ where `ORG_ID` is the key name of the partner organization stored in `config.js`
 {
   "availability": {
     "Sunday": {
-      "12a": Boolean,
-      "1a": Boolean,
+      "12a": "Boolean",
+      "1a": "Boolean",
       ...
     },
     "Monday": {

--- a/README.md
+++ b/README.md
@@ -273,7 +273,18 @@ where `ORG_ID` is the key name of the partner organization stored in `config.js`
 
 ```json
 {
-  "availability": "String"
+  "availability": {
+    "Sunday": {
+      "12a": Boolean,
+      "1a": Boolean,
+      ...
+    },
+    "Monday": {
+      ...
+    },
+    ...
+  },
+  "tz": "String"
 }
 ```
 

--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -11,17 +11,19 @@ module.exports = {
 
     // verify that all of the day-of-week and time-of-day properties are defined on the
     // new availability object
-    if (Object.keys(user.availability.toObject())
-      .some((key) => {
-        if (typeof(availability[key]) === "undefined") {
+    if (
+      Object.keys(user.availability.toObject()).some(key => {
+        if (typeof availability[key] === 'undefined') {
           // day-of-week property needs to be defined
           return true
         }
-        
+
         // time-of-day properties also need to be defined
-        return Object.keys(user.availability[key].toObject())
-          .some((key2) => typeof(availability[key][key2]) === "undefined")
-      })) {
+        return Object.keys(user.availability[key].toObject()).some(
+          key2 => typeof availability[key][key2] === 'undefined'
+        )
+      })
+    ) {
       return callback(new Error('Availability object missing required keys'))
     }
 

--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -30,12 +30,12 @@ module.exports = {
 
     user.availability = availability
     user.availabilityLastModifiedAt = new Date().toISOString()
-    
+
     // update timezone
     if (tz) {
       user.timezone = tz
     }
-    
+
     user.save(function(err, user) {
       if (err) {
         callback(err, null)

--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -1,7 +1,8 @@
 module.exports = {
-  updateAvailability: function(options, callback) {
+  updateSchedule: function(options, callback) {
     const user = options.user
     const availability = options.availability
+    const tz = options.tz
 
     // verify that availability object is defined and not null
     if (!availability) {
@@ -29,25 +30,17 @@ module.exports = {
 
     user.availability = availability
     user.availabilityLastModifiedAt = new Date().toISOString()
+    
+    // update timezone
+    if (tz) {
+      user.timezone = tz
+    }
+    
     user.save(function(err, user) {
       if (err) {
         callback(err, null)
       } else {
         callback(null, availability)
-      }
-    })
-  },
-
-  updateTimezone: function(options, callback) {
-    const user = options.user
-    const tz = options.tz
-
-    user.timezone = tz
-    user.save(function(err, user) {
-      if (err) {
-        callback(err, null)
-      } else {
-        callback(null, tz)
       }
     })
   }

--- a/controllers/CalendarCtrl.js
+++ b/controllers/CalendarCtrl.js
@@ -3,7 +3,29 @@ module.exports = {
     const user = options.user
     const availability = options.availability
 
-    user.availability.set(availability)
+    // verify that availability object is defined and not null
+    if (!availability) {
+      // early exit
+      return callback(new Error('No availability object specified'))
+    }
+
+    // verify that all of the day-of-week and time-of-day properties are defined on the
+    // new availability object
+    if (Object.keys(user.availability.toObject())
+      .some((key) => {
+        if (typeof(availability[key]) === "undefined") {
+          // day-of-week property needs to be defined
+          return true
+        }
+        
+        // time-of-day properties also need to be defined
+        return Object.keys(user.availability[key].toObject())
+          .some((key2) => typeof(availability[key][key2]) === "undefined")
+      })) {
+      return callback(new Error('Availability object missing required keys'))
+    }
+
+    user.availability = availability
     user.availabilityLastModifiedAt = new Date().toISOString()
     user.save(function(err, user) {
       if (err) {

--- a/router/api/calendar.js
+++ b/router/api/calendar.js
@@ -2,19 +2,21 @@ var CalendarCtrl = require('../../controllers/CalendarCtrl')
 
 module.exports = function(router) {
   router.post('/calendar/save', function(req, res, next) {
-    CalendarCtrl.updateSchedule({
-      user: req.user,
-      availability: req.body.availability,
-      tz: req.body.tz
-    },
-    function(err) {
-      if (err) {
-        next(err)
-      } else {
-        res.json({
-          msg: 'Schedule saved'
-        })
+    CalendarCtrl.updateSchedule(
+      {
+        user: req.user,
+        availability: req.body.availability,
+        tz: req.body.tz
+      },
+      function(err) {
+        if (err) {
+          next(err)
+        } else {
+          res.json({
+            msg: 'Schedule saved'
+          })
+        }
       }
-    })
+    )
   })
 }

--- a/router/api/calendar.js
+++ b/router/api/calendar.js
@@ -2,29 +2,17 @@ var CalendarCtrl = require('../../controllers/CalendarCtrl')
 
 module.exports = function(router) {
   router.post('/calendar/save', function(req, res, next) {
-    CalendarCtrl.updateAvailability(
-      { user: req.user, availability: req.body.availability },
-      function(err, avail) {
-        if (err) {
-          next(err)
-        } else {
-          res.json({
-            msg: 'Availability saved'
-          })
-        }
-      }
-    )
-  })
-  router.post('/calendar/tz/save', function(req, res, next) {
-    CalendarCtrl.updateTimezone({ user: req.user, tz: req.body.tz }, function(
-      err,
-      tz
-    ) {
+    CalendarCtrl.updateSchedule({
+      user: req.user,
+      availability: req.body.availability,
+      tz: req.body.tz
+    },
+    function(err) {
       if (err) {
         next(err)
       } else {
         res.json({
-          msg: 'Timezone saved'
+          msg: 'Schedule saved'
         })
       }
     })


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/214
- Web repo PR: https://github.com/UPchieve/web/pull/326

Description
-----------
- Instead of having two separate API endpoints for the single user action of clicking "Save" on the calendar view, the availability and timezone can now be updated by one endpoint, so that two network requests do not have to be processed through the Passport middleware, and two separate database queries do not have to be sent to Mongo to update the calendar. This improves the performance of calendar updating significantly; with these changes, the time to save the calendar is reduced to ~1-2 seconds.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
