### PR TITLE
fixed 3 min elapsed to one day

### DIFF
--- a/middleware/add-last-activity.js
+++ b/middleware/add-last-activity.js
@@ -4,7 +4,7 @@ function addLastActivity(req, res, next) {
   if (req.user) {
     const { id, lastActivityAt } = req.user
     const todaysDateInMS = Date.now()
-    const oneDayElapsed = 1000 * 60 * 3
+    const oneDayElapsed = 1000 * 60 * 60 * 24
     const lastActivityInMS = new Date(lastActivityAt).getTime()
 
     if (lastActivityInMS + oneDayElapsed <= todaysDateInMS) {


### PR DESCRIPTION
Description
-----------
- Fixed typo that allowed a user's `lastAcitivity` property to be updated after three minutes instead of one day

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
