### PR TITLE
push runnable dockerimage to docker repo

### DIFF
--- a/.github/workflows/docker_dockerimage.yml
+++ b/.github/workflows/docker_dockerimage.yml
@@ -1,5 +1,11 @@
 name: Publish Docker
-on: [push]
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_dockerimage.yml
+++ b/.github/workflows/docker_dockerimage.yml
@@ -1,0 +1,13 @@
+name: Publish Docker
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: upchieve/upchieve-server-examples
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Change "BAR" if you want to trigger changes to ignore cache (while preserving environment cache)
-ARG FOO=BAR1
+ARG FOO=BAR
 
 # set the base image to Debian
 # https://hub.docker.com/_/debian/
@@ -35,10 +35,6 @@ RUN source $NVM_DIR/nvm.sh \
 ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
-
-# confirm installation
-RUN node -v
-RUN npm -v
 RUN mkdir /data && mkdir /data/db
 EXPOSE 3000
 EXPOSE 3001
@@ -46,3 +42,4 @@ EXPOSE 3001
 ARG FOO
 COPY . .
 RUN bin/docker_setup.sh
+CMD bash /bin/docker_run.sh 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Local Development
 Docker provides an alternative for local development. A Dockerfile and specific run script exist. Here's how to leverage them. With Docker installed, checkout this repository and navigate into its root directory.
 
 1. Run `docker build -t local_upchieve_server/local_upchieve_server:0.1 . --rm` to create the image.
-2. Run `docker run -p 127.0.0.1:3000:3000/tcp -p 127.0.0.1:3001:3001/tcp local_upchieve_server/local_upchieve_server:0.1 bash /bin/docker_run.sh` to launch the server
+2. Run `docker run -p 127.0.0.1:3000:3000/tcp -p 127.0.0.1:3001:3001/tcp local_upchieve_server/local_upchieve_server:0.1` to launch the server
 3. After any change: In the Dockerfile, change the line `ARG FOO=BAR` to something like `ARG FOO=BAR1`, changing "BAR" to anything different from the last run. Then, repeat steps 1 and 2, which should run much quicker.
 
 


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/306
- Web repo PR: N/A
- Dependency PRs: N/A

Description
-----------
- BEFORE MERGING: @jkeat , please: 
---Verify that you have a Docker account, and that it has access to own on this org: https://hub.docker.com/u/upchieve
---Add your username and password to the UPchieve server secrets as: DOCKER_USERNAME and DOCKER_PASSWORD here: https://github.com/UPchieve/server/settings/secrets .
- In order to make the e2e tests run on CircleCI, we must have some way to invoke the server project from the web. This seems the best way to do that (uploading to Docker)

Developer self-review checklist
-------------------------------
- [X ] Potentially confusing code has been explained with comments
- [X ] No warnings or errors have been introduced; all known error cases have been handled
- [X ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [X ] All edge cases have been addressed
