### PR TITLE
Wait for user to join session before hitting socket service

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -89,7 +89,7 @@ module.exports = function(socketService) {
       try {
         const isInitialVolunteerJoin = user.isVolunteer && !session.volunteer
 
-        session.joinUser(user)
+        await session.joinUser(user)
 
         if (isInitialVolunteerJoin) {
           twilioService.stopNotifications(session)


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/236

Description
-----------
- It seems like there were race conditions with the volunteer's information being saved on the session document and when the volunteer joins that session through the socket service

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
