### PR TITLE
Fix notification cancellation

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -30,9 +30,8 @@ module.exports = function(socketService) {
 
       socketService.emitNewSession(savedSession)
 
-      twilioService.beginRegularNotifications(savedSession).then(() => {
-        twilioService.beginFailsafeNotifications(savedSession)
-      })
+      twilioService.beginRegularNotifications(savedSession)
+      twilioService.beginFailsafeNotifications(savedSession)
 
       return savedSession
     },

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -442,13 +442,8 @@ module.exports = {
       return
     }
 
-    // initial notifications
-    await notifyFailsafe(session, {
-      desperate: false,
-      voice: false
-    })
-
-    // timeout for desperate SMS notification
+    // Schedule future failsafe SMS notifications
+    // (Happens later unless session is fulfilled or ended)
     const desperateTimeout = setTimeout(
       notifyFailsafe,
       config.desperateSMSTimeout,
@@ -460,7 +455,8 @@ module.exports = {
     )
     getSessionTimeoutFor(session).timeouts.push(desperateTimeout)
 
-    // timeout for desperate voice notification
+    // Schedule future failsafe phone call notifications
+    // (Happens later unless session is fulfilled or ended)
     const desperateVoiceTimeout = setTimeout(
       notifyFailsafe,
       config.desperateVoiceTimeout,
@@ -471,6 +467,12 @@ module.exports = {
       }
     )
     getSessionTimeoutFor(session).timeouts.push(desperateVoiceTimeout)
+
+    // Send first SMS failsafe notifications (Send right now)
+    await notifyFailsafe(session, {
+      desperate: false,
+      voice: false
+    })
   },
 
   stopNotifications: function(session) {

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -415,7 +415,7 @@ module.exports = {
       return
     }
 
-    // Schedule future notification waves (once every 3 mins, starting in 3 mins)
+    // Schedule future notification waves (once every 2 mins, starting in 2 mins)
     // These will continue until the session is fulfilled or ended
     const interval = setInterval(
       async session => {

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -2,7 +2,7 @@ var config = require('../config.js')
 var User = require('../models/User')
 var twilio = require('twilio')
 var moment = require('moment-timezone')
-const client =
+const twilioClient =
   config.accountSid && config.authToken
     ? twilio(config.accountSid, config.authToken)
     : null
@@ -119,7 +119,7 @@ function sendTextMessage(phoneNumber, messageText, isTestUserRequest) {
   const fullPhoneNumber =
     phoneNumber[0] === '+' ? phoneNumber : `+1${phoneNumber}`
 
-  return client.messages
+  return twilioClient.messages
     .create({
       to: fullPhoneNumber,
       from: config.sendingNumber,
@@ -154,7 +154,7 @@ function sendVoiceMessage(phoneNumber, messageText) {
 
   // initiate call, giving Twilio the aforementioned URL which Twilio
   // opens when the call is answered to get the TwiML instructions
-  return client.calls
+  return twilioClient.calls
     .create({
       url: url,
       to: fullPhoneNumber,
@@ -409,8 +409,8 @@ module.exports = {
 
   // begin notifying non-failsafe volunteers for a session
   beginRegularNotifications: async function(session) {
-    // check that client has been authenticated
-    if (!client) {
+    // check that twilio client has been authenticated
+    if (!twilioClient) {
       // early exit
       return
     }
@@ -437,7 +437,7 @@ module.exports = {
   // begin notifying failsafe volunteers for a session
   beginFailsafeNotifications: async function(session) {
     // check that client has been authenticated
-    if (!client) {
+    if (!twilioClient) {
       // early exit
       return
     }

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -407,18 +407,16 @@ module.exports = {
       })
   },
 
-  // begin notifying non-failsafe volunteers for a session
+  // Begin notifying non-failsafe volunteers for a session
   beginRegularNotifications: async function(session) {
-    // check that twilio client has been authenticated
+    // Check that twilio client has been authenticated
     if (!twilioClient) {
       // early exit
       return
     }
 
-    // initial wave
-    await notifyRegular(session)
-
-    // set 3-minute notification interval
+    // Schedule future notification waves (once every 3 mins, starting in 3 mins)
+    // These will continue until the session is fulfilled or ended
     const interval = setInterval(
       async session => {
         const numVolunteersNotified = await notifyRegular(session)
@@ -429,9 +427,11 @@ module.exports = {
       120000,
       session
     )
-
     // store interval in memory
     getSessionTimeoutFor(session).intervals.push(interval)
+
+    // Send initial wave of notifications (right now)
+    await notifyRegular(session)
   },
 
   // begin notifying failsafe volunteers for a session

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -313,7 +313,7 @@ const notifyFailsafe = async function(session, options) {
     }
 
     if (!voice) {
-      messageText = messageText + ` ${sessionUrl}`
+      messageText = messageText + `\n${sessionUrl}`
     }
 
     const sendPromise = voice


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/239

Description
-----------
- Schedule future notifications before sending the initial waves (for regular + failsafe)
- We need to prioritize scheduling these so that they can be cleared if the session is immediately canceled. Basically the user can trigger a race condition where the session gets canceled before the future notifications are scheduled.
- Don't wait for the regular notifications to finish before kicking off the failsafe notifications. I recently changed it so that we _would_ wait, but we no longer need to send the # of regular notifications in the first failsafe message, so this isn't necessary and just slows things down.

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
