### PR TITLE
Set maxAge on session cookie

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -7,6 +7,7 @@ module.exports = {
   host: process.env.SERVER_HOST || 'localhost:3000',
   database: 'mongodb://localhost:27017/upchieve',
   sessionSecret: process.env.SESSION_SECRET || 'secret',
+  sessionCookieMaxAge: process.env.SESSION_COOKIE_MAX_AGE || 5184000000,
   saltRounds: 10,
   sendgrid: {
     apiKey: process.env.SENDGRID_API_KEY || '',

--- a/router/auth/session-store.js
+++ b/router/auth/session-store.js
@@ -16,7 +16,8 @@ module.exports = function(app) {
       secret: config.sessionSecret,
       store: sessionStore,
       cookie: {
-        httpOnly: false
+        httpOnly: false,
+        maxAge: config.sessionCookieMaxAge
       }
     })
   )


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/252

Description
-----------
- A `maxAge` is set on the session cookie so that `express-session` generates an `Expires` attribute. The `maxAge` is configurable in `config.js` or by the environment variable `SESSION_COOKIE_MAX_AGE`; the default given in the `config.example.js` is 60 days.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
