### PR TITLE
Elapsed avail partially onboarded

### DIFF
--- a/dbutils/update-partially-onboarded-users-elapsed-avail.js
+++ b/dbutils/update-partially-onboarded-users-elapsed-avail.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose')
+const dbconnect = require('./dbconnect')
+const User = require('../models/User')
+
+dbconnect(mongoose, function() {
+  User.find({ isVolunteer: true })
+    .then(listOfUsers => {
+      const pendingUpdatedUsers = listOfUsers.map(user => {
+        if (!user.isOnboarded) {
+          user.elapsedAvailability = 0
+          return user.save().catch(e => console.log(e))
+        }
+      })
+      return Promise.all(pendingUpdatedUsers)
+    })
+    .catch(err => {
+      if (err) {
+        console.log(err)
+      }
+    })
+    .finally(() => {
+      console.log('disconnecting')
+      mongoose.disconnect()
+    })
+})

--- a/models/User.js
+++ b/models/User.js
@@ -428,6 +428,11 @@ userSchema.methods.populateForVolunteerStats = function(cb) {
 // Calculates the amount of hours between this.availabilityLastModifiedAt
 // and the current time that a user updates to a new availability
 userSchema.methods.calculateElapsedAvailability = function(newModifiedDate) {
+  // A volunteer must be onboarded before calculating their elapsed availability
+  if (!this.isOnboarded) {
+    return 0
+  }
+
   const availabilityLastModifiedAt = moment(
     this.availabilityLastModifiedAt || this.createdAt
   )

--- a/tests/unit/models/User.test.js
+++ b/tests/unit/models/User.test.js
@@ -452,6 +452,17 @@ test('Test international phone number', t => {
   t.is(tempPhone, '+123456790')
 })
 
+test('Elapsed availability for partially onboarded users', async t => {
+  // EST Time Zone for dates
+  const lastModifiedDate = '2020-02-06T00:52:59.538-05:00'
+  const newModifiedDate = '2020-02-09T12:40:00.000-05:00'
+  const expected = 0
+  goodUser.availability = flexibleHoursSelected
+  goodUser.availabilityLastModifiedAt = lastModifiedDate
+  const result = goodUser.calculateElapsedAvailability(newModifiedDate)
+  t.is(expected, result)
+})
+
 test('Elapsed availability over 3 days with no hours available', t => {
   // EST Time Zone for dates
   const lastModifiedDate = '2020-02-06T12:52:59.538-05:00'
@@ -470,8 +481,18 @@ test('Elapsed availability over 3 days with all hours available and 7 hours out 
   const expected = 90
   goodUser.availability = allHoursSelected
   goodUser.availabilityLastModifiedAt = lastModifiedDate
+  // @todo Make Volunteer.test.js with an onboarded and partially onboarded Volunteer
+  // Onboard the user
+  goodUser.isVolunteer = true
+  goodUser.certifications['algebra'].passed = true
+  console.log(goodUser)
+  console.log(goodUser.isOnboarded)
   const result = goodUser.calculateElapsedAvailability(newModifiedDate)
   t.is(expected, result)
+
+  // set user back to default
+  goodUser.isVolunteer = false
+  goodUser.certifications['algebra'].passed = false
 })
 
 test('Elapsed availability over 3 days with flexible hours available', async t => {
@@ -481,8 +502,16 @@ test('Elapsed availability over 3 days with flexible hours available', async t =
   const expected = 16
   goodUser.availability = flexibleHoursSelected
   goodUser.availabilityLastModifiedAt = lastModifiedDate
+  // @todo Make Volunteer.test.js with an onboarded and partially onboarded Volunteer
+  // Onboard the user
+  goodUser.isVolunteer = true
+  goodUser.certifications['algebra'].passed = true
   const result = goodUser.calculateElapsedAvailability(newModifiedDate)
   t.is(expected, result)
+
+  // set user back to default
+  goodUser.isVolunteer = false
+  goodUser.certifications['algebra'].passed = false
 })
 
 /** 
@@ -502,6 +531,15 @@ test('Elapsed availability over 23 days with flexible hours available', async t 
   const expected = 114
   goodUser.availability = flexibleHoursSelected
   goodUser.availabilityLastModifiedAt = lastModifiedDate
+
+  // @todo Make Volunteer.test.js with an onboarded and partially onboarded Volunteer
+  // Onboard the user
+  goodUser.isVolunteer = true
+  goodUser.certifications['algebra'].passed = true
   const result = goodUser.calculateElapsedAvailability(newModifiedDate)
   t.is(expected, result)
+
+  // set user back to default
+  goodUser.isVolunteer = false
+  goodUser.certifications['algebra'].passed = false
 })


### PR DESCRIPTION
Description
-----------
- Only calculate elapsed availability for volunteers that are fully onboarded
- Set the elapsed availability to 0 for partially onboarded volunteers

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
