### PR TITLE
pass _id instead of id to user actions from user

### DIFF
--- a/router/api/session.js
+++ b/router/api/session.js
@@ -27,7 +27,7 @@ module.exports = function(router, io) {
       const ipAddress = req.ip
 
       UserActionCtrl.requestedSession(
-        user.id,
+        user._id,
         session._id,
         userAgent,
         ipAddress

--- a/router/api/training.js
+++ b/router/api/training.js
@@ -33,10 +33,10 @@ module.exports = function(router) {
       })
 
       passed
-        ? UserActionCtrl.passedQuiz(user.id, category).catch(error =>
+        ? UserActionCtrl.passedQuiz(user._id, category).catch(error =>
             Sentry.captureException(error)
           )
-        : UserActionCtrl.failedQuiz(user.id, category).catch(error =>
+        : UserActionCtrl.failedQuiz(user._id, category).catch(error =>
             Sentry.captureException(error)
           )
 
@@ -53,10 +53,10 @@ module.exports = function(router) {
   })
 
   router.get('/training/review/:category', function(req, res, next) {
-    const { id } = req.user
+    const { _id } = req.user
     const { category } = req.params
 
-    UserActionCtrl.viewedMaterials(id, category).catch(error =>
+    UserActionCtrl.viewedMaterials(_id, category).catch(error =>
       Sentry.captureException(error)
     )
 


### PR DESCRIPTION
Description
-----------
- Fixed bug where the user was not being saved on user actions: `REQUESTED SESSION`, `PASSED QUIZ`, `FAILED QUIZ`, and `VIEWED REVIEW MATERIALS`

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
