### PR TITLE
Grab _id from req.user

### DIFF
--- a/middleware/add-last-activity.js
+++ b/middleware/add-last-activity.js
@@ -2,14 +2,14 @@ const User = require('../models/User.js')
 
 function addLastActivity(req, res, next) {
   if (req.user) {
-    const { id, lastActivityAt } = req.user
+    const { _id, lastActivityAt } = req.user
     const todaysDateInMS = Date.now()
     const oneDayElapsed = 1000 * 60 * 60 * 24
     const lastActivityInMS = new Date(lastActivityAt).getTime()
 
     if (lastActivityInMS + oneDayElapsed <= todaysDateInMS) {
       const todaysDateFormatted = new Date(todaysDateInMS)
-      User.updateOne({ _id: id }, { lastActivityAt: todaysDateFormatted })
+      User.updateOne({ _id }, { lastActivityAt: todaysDateFormatted })
         .then(() => next())
         .catch(err => next(err))
     } else {

--- a/tests/integration/middleware/add-last-activity.test.js
+++ b/tests/integration/middleware/add-last-activity.test.js
@@ -14,7 +14,7 @@ test('Should execute next() when given no req.user', t => {
 
 test('Should execute next() when user has lastActivityAt value within one day range', t => {
   t.plan(1)
-  const req = { user: { id: USER_ID, lastActivityAt: new Date() } }
+  const req = { user: { _id: USER_ID, lastActivityAt: new Date() } }
   const next = () => {
     t.pass()
   }


### PR DESCRIPTION
Description
-----------
- Get `_id` from `req.user` instead of `id`

Note:
I didn't find any other instances of using `id` instead of `_id` from the user object

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
