### PR TITLE
removed err throw when user not found in deserializeUser

### DIFF
--- a/router/auth/passport.js
+++ b/router/auth/passport.js
@@ -10,7 +10,6 @@ passport.serializeUser(function(user, done) {
 passport.deserializeUser(async function(id, done) {
   try {
     const user = await User.findById(id).lean()
-    if (!user) return done(new Error('no user found'))
     return done(null, user)
   } catch (error) {
     return done(error)


### PR DESCRIPTION
Description
-----------
- Pass the empty user to the done callback when a valid id but no user is found

Note:
connect-mongo should be cleaning up our expired auth sessions by default
https://github.com/jdesboeufs/connect-mongo#remove-expired-sessions

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
