### PR TITLE
help docker on macintosh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/bcrypt*


### PR DESCRIPTION
Links
-----

Description
-----------
- bcrypt node libraries compiled on Mac do not work inside a linux docker container. This resolve that by not copying those items into Docker. Then, hey are naturally installed in the existing docker build script.

Developer self-review checklist
-------------------------------
- [X] Potentially confusing code has been explained with comments
- [X] No warnings or errors have been introduced; all known error cases have been handled
- [X] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [X] All edge cases have been addressed
