### PR TITLE
don't tell people to use mongod

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ Docker provides an alternative for local development. A docker-compose file exis
 1. Navigate to this directory and run `mkdir mongo-volume` to create a directory for the MongoDB volume.
 1. Run `cp config.example.ts config.ts` to copy the default config as your own config. 
 1. Run `docker-compose up` to launch the server.
-1. After any change: Run `docker-compose down --rmi all` to destry images and containers. Then run `docker-compose up`
+1. After any change: Run `docker-compose down --rmi all` to destry images and containers. Then run `docker-compose up` to see your changes.
 
-Note: the default command ran when starting the server will populate/refresh all seed data, so any changes will be lost unless this behavior is changed.
+Note: the default command ran when starting the server will populate/refresh all seed data, so any data changes to seed data will be overwritten.
 
 ## Without docker-compose
 If not using docker-compose, follow these steps to start required components.
@@ -111,14 +111,14 @@ docker run -i --rm --name redis -p 6379:6379 -v <Absolute Path to directory on y
 
 ### Setup
 
-1. Start a local MongoDB server by running `mongod`. In a separate terminal, you can try connecting to the database by running `mongo` (`mongod` to start the database vs. `mongo` to connect via command line!). Run `quit()` to exit the shell. You can also interface with the database using a free MongoDB GUI such as [MongoDB Compass Community](https://docs.mongodb.com/manual/administration/install-community/)
+1. Yry connecting to your database container by running `mongo` (see Mongo dependancy if this will not connect). Run `quit()` to exit the shell. You can also interface with the database using a free MongoDB GUI such as [MongoDB Compass Community](https://docs.mongodb.com/manual/administration/install-community/)
 1. Run `cp config.example.ts config.ts` to copy the default config as your own config.
 1. Run `npm install` to install the required dependancies.
-1. Run `npx ts-node init` to seed the database with users, quiz questions, schools, and zip codes
+1. Run `npx ts-node init` to seed the database with users, quiz questions, schools, and zip codes.
 1. If you want to test Twilio voice calling functionality, set the `host` property to `[your public IP address]:3000` (minus the brackets), and configure your router/firewall to allow connections to port 3000 from the Internet. Twilio will need to connect to your system to obtain TwiML instructions.
 1. Run `npm run dev` to start the dev server on `http://localhost:3000`. If you get a [`bcrypt`][bcrypt] compilement error, run `npm rebuild`.
 1. See [the web client repo](https://github.com/UPchieve/web) for client
-   installation
+   installation.
 1. (optional) Run `redis-server` and `npm run worker:dev` to start the redis database and dev worker. The dev worker will automatically attempt to connect to your local Redis instance and read jobs from there. Additionally, you can run `ts-node ./scripts/add-cron-jobs.ts` to add all repeatable jobs to the job queue.
 
 [bcrypt]: https://www.npmjs.com/package/bcrypt

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ docker run -i --rm --name redis -p 6379:6379 -v <Absolute Path to directory on y
 
 ### Setup
 
-1. Yry connecting to your database container by running `mongo` (see Mongo dependancy if this will not connect). Run `quit()` to exit the shell. You can also interface with the database using a free MongoDB GUI such as [MongoDB Compass Community](https://docs.mongodb.com/manual/administration/install-community/)
+1. Try connecting to your database container by running `mongo` (see Mongo dependancy if this will not connect). Run `quit()` to exit the shell. You can also interface with the database using a free MongoDB GUI such as [MongoDB Compass Community](https://docs.mongodb.com/manual/administration/install-community/)
 1. Run `cp config.example.ts config.ts` to copy the default config as your own config.
 1. Run `npm install` to install the required dependancies.
 1. Run `npx ts-node init` to seed the database with users, quiz questions, schools, and zip codes.


### PR DESCRIPTION
I forgot to remove mongod from the instructions.

Links
-----

Description
-----------
- I need to remove mongod from the instructions since people are already using containers.
- I cleaned up some punctuation here and there.

Developer self-review checklist
-------------------------------
- [X] Potentially confusing code has been explained with comments
- [X] No warnings or errors have been introduced; all known error cases have been handled
- [X] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [X] All edge cases have been addressed
