### PR TITLE
Emit empty object in session-change when session ends

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -67,7 +67,7 @@ module.exports = function(socketService) {
 
       await sessionService.endSession(session, user)
 
-      socketService.emitSessionChange(options.sessionId)
+      socketService.emitSessionChange(options.sessionId, {})
 
       WhiteboardCtrl.saveDocToSession(options.sessionId).then(() => {
         WhiteboardCtrl.clearDocFromCache(options.sessionId)

--- a/services/SocketService.js
+++ b/services/SocketService.js
@@ -83,15 +83,23 @@ module.exports = function(io) {
       await this.updateSessionList()
     },
 
-    emitSessionChange: async function(sessionId) {
+    emitSessionChange: async function(sessionId, eventData) {
       const session = await getSessionData(sessionId)
 
       if (session.student) {
-        this.emitToUser(session.student._id, 'session-change', session)
+        this.emitToUser(
+          session.student._id,
+          'session-change',
+          eventData || session
+        )
       }
 
       if (session.volunteer) {
-        this.emitToUser(session.volunteer._id, 'session-change', session)
+        this.emitToUser(
+          session.volunteer._id,
+          'session-change',
+          eventData || session
+        )
       }
 
       await this.updateSessionList()


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/442
- Web repo PR: https://github.com/UPchieve/web/pull/445

Description
-----------
- Emits an empty object in the `session-change` event when session ends, to reflect the fact that there is no longer a current session

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
