### PR TITLE
Updated volunteer stats

### DIFF
--- a/controllers/UserCtrl.js
+++ b/controllers/UserCtrl.js
@@ -40,28 +40,47 @@ function isOnboarded(volunteer) {
 module.exports = {
   getVolunteerStats: async user => {
     const pastSessions = await Session.find({ volunteer: user._id })
-      .select('volunteerJoinedAt endedAt')
+      .select('volunteerJoinedAt endedAt messages')
       .lean()
       .exec()
+    const threeHoursMs = 1000 * 60 * 60 * 3
+    const fifteenMinsMs = 1000 * 60 * 15
 
     const millisecondsTutored = pastSessions.reduce((totalMs, session) => {
-      if (!(session.volunteerJoinedAt && session.endedAt)) {
-        return totalMs
-      }
+      const { volunteerJoinedAt, endedAt, messages } = session
 
-      const volunteerJoinDate = new Date(session.volunteerJoinedAt)
-      const sessionEndDate = new Date(session.endedAt)
-      const sessionLengthMs = sessionEndDate - volunteerJoinDate
+      if (!(volunteerJoinedAt && endedAt)) return totalMs
 
-      // skip if session was longer than 5 hours
-      if (sessionLengthMs > 18000000) {
-        return totalMs
-      }
+      const volunteerJoinDate = new Date(volunteerJoinedAt)
+      const sessionEndDate = new Date(endedAt)
+      let sessionLengthMs = sessionEndDate - volunteerJoinDate
 
       // skip if volunteer joined after the session ended
-      if (sessionLengthMs < 0) {
-        return totalMs
+      if (sessionLengthMs < 0) return totalMs
+
+      if (messages.length === 0) return sessionLengthMs + totalMs
+
+      let latestMessageIndex = messages.length - 1
+
+      // get the latest message that was sent within a 15 minute window of the message prior.
+      // Sometimes sessions are not ended by either participant and one of the participants may send
+      // a message to see if the other participant is still active before ending the session.
+      // Exclude these messages when getting the total session end time
+      if (sessionLengthMs > threeHoursMs) {
+        while (
+          latestMessageIndex > 0 &&
+          messages[latestMessageIndex].createdAt -
+            messages[latestMessageIndex - 1].createdAt >
+            fifteenMinsMs
+        ) {
+          latestMessageIndex--
+        }
       }
+
+      const latestMessageDate = new Date(
+        messages[latestMessageIndex].createdAt
+      )
+      sessionLengthMs = latestMessageDate - volunteerJoinDate 
 
       return sessionLengthMs + totalMs
     }, 0)

--- a/controllers/UserCtrl.js
+++ b/controllers/UserCtrl.js
@@ -77,10 +77,8 @@ module.exports = {
         }
       }
 
-      const latestMessageDate = new Date(
-        messages[latestMessageIndex].createdAt
-      )
-      sessionLengthMs = latestMessageDate - volunteerJoinDate 
+      const latestMessageDate = new Date(messages[latestMessageIndex].createdAt)
+      sessionLengthMs = latestMessageDate - volunteerJoinDate
 
       return sessionLengthMs + totalMs
     }, 0)


### PR DESCRIPTION
Description
-----------
- Use the latest message sent to calculate the total tutoring hours completed for a tutor
- For sessions that are longer than 3 hours search for the latest message was sent within 15 minutes of the message before ( a better alternative might be to ignore messages sent from the same person within that 15 minute window )

Would love any thoughts on how to improve the readability

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
