### PR TITLE
fix bug where tutor hours can show negative

### DIFF
--- a/controllers/UserCtrl.js
+++ b/controllers/UserCtrl.js
@@ -80,7 +80,7 @@ module.exports = {
       const latestMessageDate = new Date(messages[latestMessageIndex].createdAt)
 
       // skip if the latest message was sent before a volunteer joined
-      if (latestMessageDate <= volunteerJoinDate) return totalMs;
+      if (latestMessageDate <= volunteerJoinDate) return totalMs
 
       sessionLengthMs = latestMessageDate - volunteerJoinDate
 

--- a/controllers/UserCtrl.js
+++ b/controllers/UserCtrl.js
@@ -78,6 +78,10 @@ module.exports = {
       }
 
       const latestMessageDate = new Date(messages[latestMessageIndex].createdAt)
+
+      // skip if the latest message was sent before a volunteer joined
+      if (latestMessageDate <= volunteerJoinDate) return totalMs;
+
       sessionLengthMs = latestMessageDate - volunteerJoinDate
 
       return sessionLengthMs + totalMs


### PR DESCRIPTION
Description
-----------
- Fixed bug where tutor hours can show up negative when the latest message is sent before a volunteer joins

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
