### PR TITLE
use key for display name if no partner name is available

### DIFF
--- a/router/auth/index.js
+++ b/router/auth/index.js
@@ -451,7 +451,7 @@ module.exports = function(app) {
       )) {
         partnerOrgs.push({
           key,
-          displayName: value.name,
+          displayName: value.name ? value.name : key,
           sites: value.sites ? value.sites : null
         })
       }
@@ -471,7 +471,7 @@ module.exports = function(app) {
       )) {
         partnerOrgs.push({
           key,
-          displayName: value.name
+          displayName: value.name ? value.name : key
         })
       }
       return res.json({


### PR DESCRIPTION
Description
-----------
- Use `key` for the display name instead of `name` from partner org when a name isn't present

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
