### PR TITLE
add _id to avoid typescript compile error

### DIFF
--- a/models/types.ts
+++ b/models/types.ts
@@ -1,6 +1,7 @@
 import { Document, Types } from 'mongoose';
 
 export interface User extends Document {
+  _id: Types.ObjectId;
   availabilityLastModifiedAt: Date;
   elapsedAvailability: number;
 }


### PR DESCRIPTION
Description
-----------
- Missing prop type on `User` interface caused a TypeScript compile error

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
