### PR TITLE
Converts PushToken service to TypeScript

### DIFF
--- a/services/PushTokenService.ts
+++ b/services/PushTokenService.ts
@@ -1,7 +1,29 @@
-const admin = require('firebase-admin')
+import { messaging } from 'firebase-admin'
+import { Types } from 'mongoose'
 
-const sendToUser = ({ title, text, data, tokens }) => {
-  return admin.messaging().sendMulticast({
+// This interface feels cleaner than inlining it in the
+// sendToUser definition
+interface sendToUserData {
+  title: string
+  text: string
+  data: {
+    path: string
+  }
+  tokens: string[]
+}
+
+// Until the Session model is converted to TS,
+// we need to represent the parts of it used in
+// sendToVolunteer() here. When that model conversion
+// is done, this can be refactored to use that model directly.
+interface Session {
+  type: string
+  subTopic: string
+  _id: Types.ObjectId
+}
+
+const sendToUser = ({ title, text, data, tokens }: sendToUserData) => {
+  return messaging().sendMulticast({
     tokens, // can also send to a topic (group of people)
     // ios and android process data a little differently, so setup separate objects for each
     apns: {
@@ -21,7 +43,10 @@ const sendToUser = ({ title, text, data, tokens }) => {
       )
     },
     android: {
-      priority: 1,
+      // TS says this needs to be a string,
+      // of 'high' | 'normal'
+      // Guessing that 1 is equivalent with 'high'
+      priority: 'high',
       data: {
         title: title,
         body: text,
@@ -37,8 +62,8 @@ const sendToUser = ({ title, text, data, tokens }) => {
   })
 }
 
-module.exports = {
-  sendVolunteerJoined: async function(session, tokens) {
+export default {
+  sendVolunteerJoined: async function(session: Session, tokens: string[]) {
     const { type, subTopic, _id } = session
     const data = {
       title: 'We found a volunteer!',


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/473

Description
-----------
- Converts the PushToken service to TS. Two main things that need review:
  - I've made an interface to represent a Session mongoose document at line 19, to be used on line 66 in the `sendVolunteerJoined` function. This is temporary until the Session model is converted to TS, then it could be brought in directly as a type. This whole PR might just want to wait until the model conversion PR is merged.
  - Converting actually surfaced a bad type in the android message object, where `priority` (line 49) is supposed to be a string of `high | normal` but was `1`. I guessed that `1` was supposed to imply `high` but if it was supposed to be equivalent to `normal` I can correct that.

Otherwise I think this is pretty close to done.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
