### PR TITLE
Add cjs export ts

### DIFF
--- a/models/Session.js
+++ b/models/Session.js
@@ -196,7 +196,7 @@ sessionSchema.statics.getUnfulfilledSessions = async function() {
   const queryAttrs = {
     volunteerJoinedAt: { $exists: false },
     endedAt: { $exists: false },
-    createdAt: { $gt: new Date(Date.now() - 24*60*60 * 1000) }
+    createdAt: { $gt: new Date(Date.now() - 24 * 60 * 60 * 1000) }
   }
 
   const sessions = await this.find(queryAttrs)

--- a/services/QueueService.ts
+++ b/services/QueueService.ts
@@ -1,6 +1,7 @@
-import config from '../config'
-import Queue from 'bull'
+import Queue from 'bull';
+import config from '../config';
 
-const queue = new Queue(config.workerQueueName, config.redisConnectionString)
+const queue = new Queue(config.workerQueueName, config.redisConnectionString);
 
-export default queue
+module.exports = queue;
+export default queue;


### PR DESCRIPTION
Description
-----------
- Added `module.exports` to `QueueService.ts` for when importing from a JS file. In `services/twilio.js`, `queue` would be wrapped in a `default` object and `queue.add` would throw a TypeError of `TypeError: queue.add is not a function`: https://github.com/UPchieve/server/blob/85a472f32eb00631bbd837394c6a85ee2ad5affd/services/twilio.js#L357
- Lint

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
