### PR TITLE
Speed session queries

### DIFF
--- a/controllers/SessionCtrl.js
+++ b/controllers/SessionCtrl.js
@@ -12,17 +12,15 @@ module.exports = function(socketService) {
       const userId = user._id
       const type = options.type
       const subTopic = options.subTopic
-      const currentSession = await Session.current(userId)
 
-      if (!userId) {
-        throw new Error('Cannot create a session without a user id')
-      } else if (user.isVolunteer) {
+      if (!userId) throw new Error('Cannot create a session without a user id')
+      if (user.isVolunteer)
         throw new Error('Volunteers cannot create new sessions')
-      } else if (!type) {
-        throw new Error('Must provide a type for a new session')
-      } else if (currentSession) {
+      if (!type) throw new Error('Must provide a type for a new session')
+
+      const currentSession = await Session.current(userId)
+      if (currentSession)
         throw new Error('Student already has an active session')
-      }
 
       const session = new Session({
         student: userId,

--- a/models/Session.js
+++ b/models/Session.js
@@ -170,6 +170,7 @@ sessionSchema.methods.addNotifications = function(notificationsToAdd, cb) {
 }
 
 sessionSchema.statics.findLatest = function(attrs, cb) {
+  // @todo: refactor this query
   return this.find(attrs)
     .sort({ createdAt: -1 })
     .limit(1)
@@ -182,19 +183,16 @@ sessionSchema.statics.findLatest = function(attrs, cb) {
 // user's current session
 sessionSchema.statics.current = function(userId, cb) {
   return this.findLatest({
-    $and: [
-      { endedAt: { $exists: false } },
-      {
-        $or: [{ student: userId }, { volunteer: userId }]
-      }
-    ]
+    endedAt: { $exists: false },
+    $or: [{ student: userId }, { volunteer: userId }]
   })
 }
 
 // sessions that have not yet been fulfilled by a volunteer
 sessionSchema.statics.getUnfulfilledSessions = async function() {
+  // @note: this query is sorted in memory and uses the volunteer: 1, endedAt: 1 index
   const queryAttrs = {
-    volunteerJoinedAt: { $exists: false },
+    volunteer: { $exists: false },
     endedAt: { $exists: false },
     createdAt: { $gt: new Date(Date.now() - 24 * 60 * 60 * 1000) }
   }

--- a/router/api/session.js
+++ b/router/api/session.js
@@ -115,9 +115,11 @@ module.exports = function(router, io) {
     }
   })
 
+  // @todo: switch to a GET request
   router.route('/session/current').post(async function(req, res, next) {
-    const data = req.body || {}
-    const userId = ObjectId(data.user_id)
+    const {
+      user: { _id: userId }
+    } = req
 
     try {
       const currentSession = await Session.current(userId)


### PR DESCRIPTION
Description
-----------
- Moved checking for the current session after checking conditionals 
- Updated the `getStaleSessions` query to only search for stale sessions in the window of time since its last run. Currently, it checks all sessions with a `createdAt` longer than 12 hours ago
- Have `getUnfullfilledSessions` utilize the compound index of `volunteer: 1, endedAt: 1` instead of the `createdAt: 1` index. This resulted in fewer documents and index keys examined, but it now sorts the sessions in memory
- Removed `$and` operator from `this.findLatest` query since mongoose find queries are an implicit `and`

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
