### PR TITLE
prioritize volunteers who do not have a high-level subject

### DIFF
--- a/services/twilio.js
+++ b/services/twilio.js
@@ -50,7 +50,7 @@ const getNextVolunteer = async ({ subtopic, priorityFilter = {} }) => {
   const filter = {
     isApproved: true,
     [availabilityPath]: true,
-    // @note: subjects gets overriden by priorityFilter when searching
+    // @note: subjects gets overwritten by priorityFilter when searching
     //        for volunteers that do not have a high-level subject
     subjects: subtopic,
     phone: { $exists: true },

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -177,9 +177,6 @@ const getVolunteersNotifiedSince = async sinceDate => {
 const notifyVolunteer = async session => {
   let subtopic = session.subTopic
   const activeSessionVolunteers = await getActiveSessionVolunteers()
-  const notifiedLastFiveMins = await getVolunteersNotifiedSince(
-    relativeDate(5 * 60 * 1000)
-  )
   const notifiedLastFifteenMins = await getVolunteersNotifiedSince(
     relativeDate(15 * 60 * 1000)
   )
@@ -204,7 +201,7 @@ const notifyVolunteer = async session => {
    * 4. Regular volunteers - not notified in the last 3 days AND they don’t have "high level subjects"
    * 5. Partner volunteers - not notified in the last 3 days
    * 6. All volunteers - not notified in the last 15 mins who don't have "high level subjects"
-   * 7. All volunteers - not notified in the last 5 mins
+   * 7. All volunteers - not notified in the last 15 mins
    */
   const volunteerPriority = [
     {
@@ -262,10 +259,10 @@ const notifyVolunteer = async session => {
       }
     },
     {
-      groupName: 'All volunteers - not notified in the last 5 mins',
+      groupName: 'All volunteers - not notified in the last 15 mins',
       filter: {
         subjects: subtopic,
-        _id: { $nin: activeSessionVolunteers.concat(notifiedLastFiveMins) }
+        _id: { $nin: activeSessionVolunteers.concat(notifiedLastFifteenMins) }
       }
     }
   ]

--- a/services/twilio.js
+++ b/services/twilio.js
@@ -195,7 +195,8 @@ const notifyVolunteer = async session => {
   const highLevelSubjects = ['calculusAB', 'chemistry']
   const isHighLevelSubject = highLevelSubjects.includes(subtopic)
   let subjectsFilter = {
-    $and: [{ subjects: { $nin: highLevelSubjects } }, { subjects: subtopic }]
+    $nin: highLevelSubjects,
+    $eq: subtopic
   }
   if (isHighLevelSubject) subjectsFilter = subtopic
 


### PR DESCRIPTION
Description
-----------
- Prioritize volunteers who do not have a high-level subject. The goal of this is to avoid having a lack of high-level volunteers when a high-level subject is requested - high-level subject meaning `chemistry` or `calculusAB`

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
