### PR TITLE
move from now deprecated set-env

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -53,7 +53,7 @@ jobs:
         path: 'web'
         ref: ${{ github.head_ref }}
     - run: cd web && npm install
-    - uses: cypress-io/github-action@v1
+    - uses: cypress-io/github-action@v2
       with:
         working-directory: ./web
         browser: chrome

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -32,10 +32,10 @@ jobs:
         if curl --head --silent --fail "https://github.com/UPchieve/web/tree/${{ github.head_ref }}" 2> /dev/null;
          then
           echo "found companion branch"
-          echo "::set-env name=HAS_SAME_WEB_BRANCH::1"
+          echo "name=HAS_SAME_WEB_BRANCH::1" >> $GITHUB_ENV
          else
           echo "did not find companion branch"
-          echo "::set-env name=HAS_SAME_WEB_BRANCH::0"
+          echo "name=HAS_SAME_WEB_BRANCH::0" >> $GITHUB_ENV
         fi
     # If no matching branch is found in web, checkout master to $GITHUB_WORKSPACE/web
     - name: Checkout default (master) branch from server repo (if there is no matching branch in web)


### PR DESCRIPTION
Links
-----
- Web repo PR: https://github.com/UPchieve/web/pull/572

Description
-----------
- GitHub actions deprecated and disabled the `set-env` command - https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
   - [Setting an env variable](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files) 



Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
