### PR TITLE
Add time tutored

### DIFF
--- a/dbutils/add-time-tutored-to-sessions.ts
+++ b/dbutils/add-time-tutored-to-sessions.ts
@@ -1,0 +1,71 @@
+import mongoose from 'mongoose';
+import dbconnect from './dbconnect';
+import SessionModel from '../models/Session';
+import { calculateTimeTutored } from '../services/SessionService';
+
+// Add timeTutored to sessions
+async function upgrade(): Promise<void> {
+  try {
+    await dbconnect();
+
+    const sessions = await SessionModel.find({
+      endedAt: { $exists: true }
+    })
+      .sort({ createdAt: -1 })
+      .select({ whiteboardDoc: 0, quillDoc: 0 })
+      .lean()
+      .exec();
+    const updates = [];
+    for (const session of sessions) {
+      // older sessions with a `volunteer` but no `volunteerJoinedAt` will return NaN
+      const timeTutored = calculateTimeTutored(session);
+
+      updates.push(
+        SessionModel.updateOne(
+          {
+            _id: session._id
+          },
+          {
+            timeTutored: isNaN(timeTutored) ? 0 : timeTutored
+          }
+        )
+      );
+    }
+
+    const results = await Promise.all(updates);
+    console.log(results);
+  } catch (error) {
+    console.error(error);
+  }
+
+  mongoose.disconnect();
+}
+
+// Add availability from availability snapshots to volunteers
+async function downgrade(): Promise<void> {
+  try {
+    await dbconnect();
+
+    const results = await SessionModel.updateMany(
+      {},
+      {
+        $unset: {
+          timeTutored: ''
+        }
+      }
+    );
+    console.log(results);
+  } catch (error) {
+    console.error(error);
+  }
+
+  mongoose.disconnect();
+}
+
+// To downgrade the migration run:
+// DOWNGRADE=true npx ts-node dbutils/add-time-tutored-to-sessions.ts
+if (process.env.DOWNGRADE) {
+  downgrade();
+} else {
+  upgrade();
+}

--- a/dbutils/add-time-tutored-to-volunteers.ts
+++ b/dbutils/add-time-tutored-to-volunteers.ts
@@ -1,0 +1,70 @@
+import mongoose, { Types, Document } from 'mongoose';
+import dbconnect from './dbconnect';
+import VolunteerModel from '../models/Volunteer';
+
+interface Volunteer {
+  _id: Types.ObjectId;
+  hoursTutored: number;
+}
+
+// Add timeTutored to volunteers
+async function upgrade(): Promise<void> {
+  try {
+    await dbconnect();
+
+    const volunteers = await VolunteerModel.find()
+      .select({ hoursTutored: 1 })
+      .lean()
+      .exec();
+    const updates = [];
+    for (const volunteer of volunteers) {
+      const { hoursTutored, _id } = volunteer as Volunteer;
+      const timeTutored = Number(hoursTutored.toString()) * 3600000;
+
+      updates.push(
+        VolunteerModel.updateOne(
+          {
+            _id
+          },
+          {
+            timeTutored
+          }
+        )
+      );
+    }
+
+    const results = await Promise.all(updates);
+    console.log(results);
+  } catch (error) {
+    console.error(error);
+  }
+
+  mongoose.disconnect();
+}
+
+// Remove time tutored
+async function downgrade(): Promise<void> {
+  try {
+    await dbconnect();
+
+    const results = await VolunteerModel.updateMany(
+      {},
+      {
+        $unset: { timeTutored: '' }
+      }
+    );
+    console.log(results);
+  } catch (error) {
+    console.error(error);
+  }
+
+  mongoose.disconnect();
+}
+
+// To downgrade the migration run:
+// DOWNGRADE=true npx ts-node dbutils/add-time-tutored-to-volunteers.ts
+if (process.env.DOWNGRADE) {
+  downgrade();
+} else {
+  upgrade();
+}

--- a/models/Session.js
+++ b/models/Session.js
@@ -94,7 +94,8 @@ const sessionSchema = new mongoose.Schema({
     enum: values(SESSION_FLAGS)
   },
   reviewedStudent: Boolean,
-  reviewedVolunteer: Boolean
+  reviewedVolunteer: Boolean,
+  timeTutored: { type: Number, default: 0 }
 })
 
 sessionSchema.methods.addNotifications = function(notificationsToAdd, cb) {

--- a/models/Volunteer.ts
+++ b/models/Volunteer.ts
@@ -210,6 +210,7 @@ const volunteerSchema = new mongoose.Schema(
     },
     timezone: String,
     hoursTutored: { type: mongoose.Types.Decimal128, default: 0 },
+    timeTutored: { type: Number, default: 0 },
     availabilityLastModifiedAt: { type: Date },
     elapsedAvailability: { type: Number, default: 0 },
     sentReadyToCoachEmail: {

--- a/tests/generate.ts
+++ b/tests/generate.ts
@@ -164,6 +164,7 @@ export const buildVolunteer = (overrides = {}): Volunteer => {
     trainingCourses: buildTrainingCourses(),
     sentReadyToCoachEmail: false,
     hoursTutored: Types.Decimal128.fromString('0'),
+    timeTutored: 0,
     pastSessions: [],
     ...overrides
   };
@@ -289,6 +290,7 @@ export const buildSession = (overrides = {}): Partial<Session> => {
     isReported: false,
     reportReason: null,
     reportMessage: null,
+    timeTutored: 0,
     ...overrides
   };
 

--- a/tests/services/SessionService.test.ts
+++ b/tests/services/SessionService.test.ts
@@ -81,29 +81,28 @@ beforeEach(async () => {
   jest.clearAllMocks();
 });
 
-describe('calculateHoursTutored', () => {
+describe('calculateTimeTutored', () => {
   const similarTestCases = [
-    'Return 0 hours tutored if no volunteer has joined the session',
-    'Return 0 hours tutored if no volunteerJoinedAt and no endedAt',
-    'Return 0 hours tutored if no messages were sent during the session'
+    'Return 0ms if no volunteer has joined the session',
+    'Return 0ms if no volunteerJoinedAt and no endedAt',
+    'Return 0ms if no messages were sent during the session'
   ];
   for (const testCase of similarTestCases) {
     test(testCase, async () => {
-      const { session } = await insertSession();
-      const result = await SessionService.calculateHoursTutored(session);
-      const expectedHoursTutored = 0;
+      const session = buildSession();
+      const result = SessionService.calculateTimeTutored(session);
+      const expectedTimeTutored = 0;
 
-      expect(result).toEqual(expectedHoursTutored);
+      expect(result).toEqual(expectedTimeTutored);
     });
   }
 
-  test('Return 0 hours tutored if volunteer joined after session ended', async () => {
+  test('Return 0ms if volunteer joined after session ended', () => {
     const createdAt = new Date('2020-10-05T12:00:00.000Z');
     const endedAt = new Date('2020-10-05T12:05:00.000Z');
     const volunteerJoinedAt = new Date('2020-10-05T12:10:00.000Z');
-
-    const volunteer = await insertVolunteer();
-    const { session } = await insertSession({
+    const volunteer = buildVolunteer();
+    const session = buildSession({
       createdAt,
       endedAt,
       volunteerJoinedAt,
@@ -114,19 +113,19 @@ describe('calculateHoursTutored', () => {
       })
     });
 
-    const result = await SessionService.calculateHoursTutored(session);
-    const expectedHoursTutored = 0;
+    const result = SessionService.calculateTimeTutored(session);
+    const expectedTimeTutored = 0;
 
-    expect(result).toEqual(expectedHoursTutored);
+    expect(result).toEqual(expectedTimeTutored);
   });
 
-  test('Return 0 hours tutored if latest message was sent before a volunteer joined', async () => {
+  test('Return 0ms if latest message was sent before a volunteer joined', () => {
     const createdAt = new Date('2020-10-05T12:00:00.000Z');
     const endedAt = new Date('2020-10-05T12:05:00.000Z');
     const volunteerJoinedAt = new Date('2020-10-05T12:10:00.000Z');
-    const student = await insertStudent();
-    const volunteer = await insertVolunteer();
-    const { session } = await insertSession({
+    const student = buildStudent();
+    const volunteer = buildVolunteer();
+    const session = buildSession({
       createdAt,
       endedAt,
       volunteerJoinedAt,
@@ -138,42 +137,43 @@ describe('calculateHoursTutored', () => {
       })
     });
 
-    const result = await SessionService.calculateHoursTutored(session);
-    const expectedHoursTutored = 0;
+    const result = SessionService.calculateTimeTutored(session);
+    const expectedTimeTutored = 0;
 
-    expect(result).toEqual(expectedHoursTutored);
+    expect(result).toEqual(expectedTimeTutored);
   });
 
-  test('Should return amount of hours tutored', async () => {
+  test('Should return amount of time tutored', () => {
     const createdAt = new Date('2020-10-05T12:00:00.000Z');
     const endedAt = new Date('2020-10-05T12:05:00.000Z');
     const volunteerJoinedAt = new Date('2020-10-05T12:01:00.000Z');
-
-    const volunteer = await insertVolunteer();
-    const { session } = await insertSession({
+    const volunteer = buildVolunteer();
+    const lastMessageSentAt = new Date('2020-10-05T12:03:00.000Z');
+    const session = buildSession({
       createdAt,
       endedAt,
       volunteerJoinedAt,
       volunteer: volunteer._id,
       messages: buildMessage({
         user: volunteer._id,
-        createdAt: new Date('2020-10-05T12:03:00.000Z')
+        createdAt: lastMessageSentAt
       })
     });
 
-    const result = await SessionService.calculateHoursTutored(session);
-    const expectedHoursTutored = 0.03;
+    const result = SessionService.calculateTimeTutored(session);
+    const expectedTimeTutored =
+      lastMessageSentAt.getTime() - volunteerJoinedAt.getTime();
 
-    expect(result).toEqual(expectedHoursTutored);
+    expect(result).toEqual(expectedTimeTutored);
   });
 
-  test('Should add hours tutored to user for sessions less than 3 hours', async () => {
+  test('Should calculate time tutored for sessions less than 3 hours', () => {
     const createdAt = new Date('2020-10-05T11:55:00.000Z');
     const endedAt = new Date('2020-10-06T14:06:00.000Z');
     const volunteerJoinedAt = new Date('2020-10-05T12:00:00.000Z');
-
-    const volunteer = await insertVolunteer();
-    const { session } = await insertSessionWithVolunteer({
+    const volunteer = buildVolunteer();
+    const lastMessageSentAt = new Date('2020-10-05T14:05:00.000Z');
+    const session = buildSession({
       createdAt,
       endedAt,
       volunteerJoinedAt,
@@ -186,20 +186,21 @@ describe('calculateHoursTutored', () => {
       ]
     });
 
-    const hoursTutored = SessionService.calculateHoursTutored(session);
-    const expectedHoursTutored = 2.08;
-    expect(hoursTutored).toEqual(expectedHoursTutored);
+    const result = SessionService.calculateTimeTutored(session);
+    const expectedTimeTutored =
+      lastMessageSentAt.getTime() - volunteerJoinedAt.getTime();
+    expect(result).toEqual(expectedTimeTutored);
   });
 
   // When sessions are greater than 3 hours, use the last messages that were sent
   // within a 15 minute window to get an estimate of the session length / hours tutored
-  test('Should add hours tutored to user for sessions greater than 3 hours', async () => {
+  test('Should calculate time tutored for sessions greater than 3 hours', () => {
     const createdAt = new Date('2020-10-05T11:55:00.000Z');
     const endedAt = new Date('2020-10-06T16:00:00.000Z');
     const volunteerJoinedAt = new Date('2020-10-05T12:00:00.000Z');
-
-    const volunteer = await insertVolunteer();
-    const { session } = await insertSession({
+    const volunteer = buildVolunteer();
+    const lastMessageSentAt = new Date('2020-10-05T15:59:00.000Z');
+    const session = buildSession({
       createdAt,
       endedAt,
       volunteerJoinedAt,
@@ -215,14 +216,15 @@ describe('calculateHoursTutored', () => {
         }),
         buildMessage({
           user: volunteer._id,
-          createdAt: new Date('2020-10-05T15:59:00.000Z')
+          createdAt: lastMessageSentAt
         })
       ]
     });
 
-    const hoursTutored = SessionService.calculateHoursTutored(session);
-    const expectedHoursTutored = 3.98;
-    expect(hoursTutored).toEqual(expectedHoursTutored);
+    const result = SessionService.calculateTimeTutored(session);
+    const expectedTimeTutored =
+      lastMessageSentAt.getTime() - volunteerJoinedAt.getTime();
+    expect(result).toEqual(expectedTimeTutored);
   });
 });
 

--- a/tests/services/SessionService.test.ts
+++ b/tests/services/SessionService.test.ts
@@ -147,17 +147,19 @@ describe('calculateTimeTutored', () => {
     const createdAt = new Date('2020-10-05T12:00:00.000Z');
     const endedAt = new Date('2020-10-05T12:05:00.000Z');
     const volunteerJoinedAt = new Date('2020-10-05T12:01:00.000Z');
-    const volunteer = buildVolunteer();
     const lastMessageSentAt = new Date('2020-10-05T12:03:00.000Z');
+    const volunteer = buildVolunteer();
     const session = buildSession({
       createdAt,
       endedAt,
       volunteerJoinedAt,
       volunteer: volunteer._id,
-      messages: buildMessage({
-        user: volunteer._id,
-        createdAt: lastMessageSentAt
-      })
+      messages: [
+        buildMessage({
+          user: volunteer._id,
+          createdAt: lastMessageSentAt
+        })
+      ]
     });
 
     const result = SessionService.calculateTimeTutored(session);
@@ -171,8 +173,8 @@ describe('calculateTimeTutored', () => {
     const createdAt = new Date('2020-10-05T11:55:00.000Z');
     const endedAt = new Date('2020-10-06T14:06:00.000Z');
     const volunteerJoinedAt = new Date('2020-10-05T12:00:00.000Z');
-    const volunteer = buildVolunteer();
     const lastMessageSentAt = new Date('2020-10-05T14:05:00.000Z');
+    const volunteer = buildVolunteer();
     const session = buildSession({
       createdAt,
       endedAt,
@@ -181,7 +183,7 @@ describe('calculateTimeTutored', () => {
       messages: [
         buildMessage({
           user: volunteer._id,
-          createdAt: new Date('2020-10-05T14:05:00.000Z')
+          createdAt: lastMessageSentAt
         })
       ]
     });
@@ -198,8 +200,8 @@ describe('calculateTimeTutored', () => {
     const createdAt = new Date('2020-10-05T11:55:00.000Z');
     const endedAt = new Date('2020-10-06T16:00:00.000Z');
     const volunteerJoinedAt = new Date('2020-10-05T12:00:00.000Z');
-    const volunteer = buildVolunteer();
     const lastMessageSentAt = new Date('2020-10-05T15:59:00.000Z');
+    const volunteer = buildVolunteer();
     const session = buildSession({
       createdAt,
       endedAt,

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -76,6 +76,7 @@ export interface Volunteer extends User {
   trainingCourses: TrainingCourses;
   sentReadyToCoachEmail: boolean;
   hoursTutored: Types.Decimal128;
+  timeTutored: number;
 }
 
 export interface StudentRegistrationForm extends Student {
@@ -230,4 +231,5 @@ export interface Session {
   flags: string[];
   reviewedStudent: boolean;
   reviewedVolunteer: boolean;
+  timeTutored: number;
 }


### PR DESCRIPTION
Description
-----------
- When ending a session, `timeTutored` is added to the session doc and increased for the volunteer doc
- Migration scripts to add `timeTutored` to both volunteers and sessions
- Updated tests to reflect the change of `calculateHoursTutored` to `calculateTimeTutored`
- Added `timeTutored` to the Session and Volunteer model

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
